### PR TITLE
feat(progression): level-up rewards + milestone unlocks (PR #2)

### DIFF
--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -732,6 +732,64 @@
 
   const XP_PER_LEVEL = (lvl) => Math.floor(160 + Math.pow(lvl, 1.65) * 55);
 
+  // ---- Level-up rewards & milestone unlocks (PR #2) ----
+  // Every level pays scaling credits; milestones unlock abilities/ships/caches
+  // so all 20 abilities are earned by L30 and all ships by L35 through play.
+  const LEVEL_BASE_CREDIT = (lvl) => 50 + lvl * 10;
+  const LEVEL_MILESTONES = {
+    2:  { abilities: [['primary', 'scatter']] },
+    3:  { abilities: [['secondary', 'cluster']] },
+    4:  { credits: 500 },
+    5:  { ships: ['phantom'], abilities: [['defense', 'reflector']] },
+    6:  { abilities: [['primary', 'rail']] },
+    7:  { abilities: [['secondary', 'seeker']] },
+    8:  { abilities: [['ultimate', 'solarbeam']] },
+    9:  { credits: 800 },
+    10: { ships: ['bulwark'], abilities: [['primary', 'ionburst']] },
+    12: { abilities: [['secondary', 'gravity']] },
+    13: { abilities: [['defense', 'phaseshift']] },
+    15: { ships: ['emberwing'], abilities: [['primary', 'plasma']], credits: 1200 },
+    18: { abilities: [['secondary', 'charge']] },
+    20: { ships: ['spectre'], abilities: [['ultimate', 'timewarp']] },
+    22: { abilities: [['primary', 'photon']] },
+    25: { abilities: [['defense', 'overcharge']], credits: 2000 },
+    28: { abilities: [['secondary', 'reinforcement']] },
+    30: { abilities: [['ultimate', 'supernova']], credits: 2500 },
+    35: { ships: ['titan'] },
+    40: { credits: 4000 }
+  };
+  const abilityName = (cat, id) => {
+    try { return (ARMORY_MAP[cat] && ARMORY_MAP[cat][id] && ARMORY_MAP[cat][id].name) || id; }
+    catch (e) { return id; }
+  };
+  const shipName = (id) => {
+    try { const s = SHIP_TEMPLATES.find(t => t.id === id); return s ? s.name : id; }
+    catch (e) { return id; }
+  };
+  const grantLevelRewards = (level) => {
+    const base = LEVEL_BASE_CREDIT(level);
+    Save.addCredits(base);
+    if (typeof addLogEntry === 'function') addLogEntry(`+${base} credits`, '#fbbf24');
+    const m = LEVEL_MILESTONES[level];
+    if (!m) return;
+    if (m.credits) {
+      Save.addCredits(m.credits);
+      if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDCB0 Bonus +${m.credits} credits!`, '#fbbf24');
+    }
+    if (Array.isArray(m.abilities)) {
+      for (const [cat, id] of m.abilities) {
+        Save.unlockArmory(cat, id);
+        if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDD13 New ${cat}: ${abilityName(cat, id)}!`, '#4ade80');
+      }
+    }
+    if (Array.isArray(m.ships)) {
+      for (const sid of m.ships) {
+        Save.unlockShip(sid);
+        if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDE80 Ship unlocked: ${shipName(sid)}!`, '#60a5fa');
+      }
+    }
+  };
+
   /* ====== DOM ====== */
   const dom = {};
   const assignDomRefs = () => {
@@ -2064,6 +2122,8 @@
       if (typeof AudioManager !== 'undefined') {
         AudioManager.playLevelUp();
       }
+
+      grantLevelRewards(pilotLevel);
     }
     Save.data.pilotLevel = pilotLevel;
     Save.data.pilotXp = pilotXP;

--- a/rewards-system.test.js
+++ b/rewards-system.test.js
@@ -1,0 +1,57 @@
+/**
+ * PR #2 — level-up rewards & milestone unlock coverage.
+ * Mirrors LEVEL_MILESTONES from script.js as a design-contract regression guard.
+ */
+const LEVEL_BASE_CREDIT = (lvl) => 50 + lvl * 10;
+const LEVEL_MILESTONES = {
+  2:{abilities:[['primary','scatter']]}, 3:{abilities:[['secondary','cluster']]}, 4:{credits:500},
+  5:{ships:['phantom'],abilities:[['defense','reflector']]}, 6:{abilities:[['primary','rail']]},
+  7:{abilities:[['secondary','seeker']]}, 8:{abilities:[['ultimate','solarbeam']]}, 9:{credits:800},
+  10:{ships:['bulwark'],abilities:[['primary','ionburst']]}, 12:{abilities:[['secondary','gravity']]},
+  13:{abilities:[['defense','phaseshift']]}, 15:{ships:['emberwing'],abilities:[['primary','plasma']],credits:1200},
+  18:{abilities:[['secondary','charge']]}, 20:{ships:['spectre'],abilities:[['ultimate','timewarp']]},
+  22:{abilities:[['primary','photon']]}, 25:{abilities:[['defense','overcharge']],credits:2000},
+  28:{abilities:[['secondary','reinforcement']]}, 30:{abilities:[['ultimate','supernova']],credits:2500},
+  35:{ships:['titan']}, 40:{credits:4000}
+};
+const STARTERS = { primary:['pulse'], secondary:['nova'], defense:['aegis'], ultimate:['voidstorm'] };
+const ALL = {
+  primary:['pulse','scatter','rail','ionburst','plasma','photon'],
+  secondary:['nova','cluster','seeker','gravity','charge','reinforcement'],
+  defense:['aegis','reflector','phaseshift','overcharge'],
+  ultimate:['voidstorm','solarbeam','timewarp','supernova']
+};
+
+const grantedAbilitiesBy = (maxLvl) => {
+  const owned = { primary:[...STARTERS.primary], secondary:[...STARTERS.secondary], defense:[...STARTERS.defense], ultimate:[...STARTERS.ultimate] };
+  for (let l=1; l<=maxLvl; l++) for (const [c,id] of (LEVEL_MILESTONES[l]?.abilities||[])) owned[c].push(id);
+  return owned;
+};
+const grantedShipsBy = (maxLvl) => {
+  const s=['vanguard']; for (let l=1; l<=maxLvl; l++) for (const id of (LEVEL_MILESTONES[l]?.ships||[])) s.push(id); return s;
+};
+
+describe('Level-up rewards & milestone unlocks', () => {
+  test('base credit reward scales per level', () => {
+    expect(LEVEL_BASE_CREDIT(1)).toBe(60);
+    expect(LEVEL_BASE_CREDIT(10)).toBe(150);
+    expect(LEVEL_BASE_CREDIT(50)).toBe(550);
+  });
+  test('every ability is unlockable by level 30', () => {
+    const owned = grantedAbilitiesBy(30);
+    for (const cat of Object.keys(ALL)) for (const id of ALL[cat]) expect(owned[cat]).toContain(id);
+    const total = Object.values(owned).reduce((a,b)=>a+b.length,0);
+    expect(total).toBe(20);
+  });
+  test('all 6 ships unlockable by level 35', () => {
+    const ships = grantedShipsBy(35);
+    expect(new Set(ships)).toEqual(new Set(['vanguard','phantom','bulwark','emberwing','spectre','titan']));
+  });
+  test('no ability or ship is granted twice', () => {
+    const seen = new Set();
+    for (const m of Object.values(LEVEL_MILESTONES)) {
+      for (const [c,id] of (m.abilities||[])) { const k=c+':'+id; expect(seen.has(k)).toBe(false); seen.add(k); }
+      for (const s of (m.ships||[])) { expect(seen.has('ship:'+s)).toBe(false); seen.add('ship:'+s); }
+    }
+  });
+});

--- a/script.js
+++ b/script.js
@@ -732,6 +732,64 @@
 
   const XP_PER_LEVEL = (lvl) => Math.floor(160 + Math.pow(lvl, 1.65) * 55);
 
+  // ---- Level-up rewards & milestone unlocks (PR #2) ----
+  // Every level pays scaling credits; milestones unlock abilities/ships/caches
+  // so all 20 abilities are earned by L30 and all ships by L35 through play.
+  const LEVEL_BASE_CREDIT = (lvl) => 50 + lvl * 10;
+  const LEVEL_MILESTONES = {
+    2:  { abilities: [['primary', 'scatter']] },
+    3:  { abilities: [['secondary', 'cluster']] },
+    4:  { credits: 500 },
+    5:  { ships: ['phantom'], abilities: [['defense', 'reflector']] },
+    6:  { abilities: [['primary', 'rail']] },
+    7:  { abilities: [['secondary', 'seeker']] },
+    8:  { abilities: [['ultimate', 'solarbeam']] },
+    9:  { credits: 800 },
+    10: { ships: ['bulwark'], abilities: [['primary', 'ionburst']] },
+    12: { abilities: [['secondary', 'gravity']] },
+    13: { abilities: [['defense', 'phaseshift']] },
+    15: { ships: ['emberwing'], abilities: [['primary', 'plasma']], credits: 1200 },
+    18: { abilities: [['secondary', 'charge']] },
+    20: { ships: ['spectre'], abilities: [['ultimate', 'timewarp']] },
+    22: { abilities: [['primary', 'photon']] },
+    25: { abilities: [['defense', 'overcharge']], credits: 2000 },
+    28: { abilities: [['secondary', 'reinforcement']] },
+    30: { abilities: [['ultimate', 'supernova']], credits: 2500 },
+    35: { ships: ['titan'] },
+    40: { credits: 4000 }
+  };
+  const abilityName = (cat, id) => {
+    try { return (ARMORY_MAP[cat] && ARMORY_MAP[cat][id] && ARMORY_MAP[cat][id].name) || id; }
+    catch (e) { return id; }
+  };
+  const shipName = (id) => {
+    try { const s = SHIP_TEMPLATES.find(t => t.id === id); return s ? s.name : id; }
+    catch (e) { return id; }
+  };
+  const grantLevelRewards = (level) => {
+    const base = LEVEL_BASE_CREDIT(level);
+    Save.addCredits(base);
+    if (typeof addLogEntry === 'function') addLogEntry(`+${base} credits`, '#fbbf24');
+    const m = LEVEL_MILESTONES[level];
+    if (!m) return;
+    if (m.credits) {
+      Save.addCredits(m.credits);
+      if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDCB0 Bonus +${m.credits} credits!`, '#fbbf24');
+    }
+    if (Array.isArray(m.abilities)) {
+      for (const [cat, id] of m.abilities) {
+        Save.unlockArmory(cat, id);
+        if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDD13 New ${cat}: ${abilityName(cat, id)}!`, '#4ade80');
+      }
+    }
+    if (Array.isArray(m.ships)) {
+      for (const sid of m.ships) {
+        Save.unlockShip(sid);
+        if (typeof addLogEntry === 'function') addLogEntry(`\uD83D\uDE80 Ship unlocked: ${shipName(sid)}!`, '#60a5fa');
+      }
+    }
+  };
+
   /* ====== DOM ====== */
   const dom = {};
   const assignDomRefs = () => {
@@ -2064,6 +2122,8 @@
       if (typeof AudioManager !== 'undefined') {
         AudioManager.playLevelUp();
       }
+
+      grantLevelRewards(pilotLevel);
     }
     Save.data.pilotLevel = pilotLevel;
     Save.data.pilotXp = pilotXP;


### PR DESCRIPTION
Builds on the PR #1 hybrid save schema.

## Adds
- Per-level credit reward: 50 + level*10 on every pilot level-up.
- Milestone unlock table: abilities + ships + credit caches granted through play. All 20 abilities earned by L30, all 6 ships by L35 — makes orphaned abilities reachable and unlock achievements completable.
- Account-wide ability ownership + ship unlocks via the hybrid save API.
- rewards-system.test.js: coverage + no-duplicate + credit-formula tests.

## Verified
node --check OK; eslint 0 net-new errors; jest all pass (incl. 4 new); headless boot+start smoke test zero console errors.

## Follow-up
PR #3 buy-to-unlock UI; PR #4 Game Center; PR #5 privacy manifest.