### PR TITLE
Daily improvement loop: achievement wiring fix, new power-ups, Close Call bonus, Hangar Loadout tab

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1237,6 +1237,15 @@ const HANGAR_UI_CSS = `
   .hangar-theme-swatch.active { border-color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.3); transform: scale(1.1); }
   .hangar-theme-hint { font-size: 11px; color: rgba(255,255,255,0.35); margin-top: 8px; }
 
+  /* ── Accessibility section ───────────────────────────────── */
+  .hangar-accessibility-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
+  .hangar-toggle-switch { position: relative; display: inline-block; width: 42px; height: 24px; flex-shrink: 0; }
+  .hangar-toggle-switch input { opacity: 0; width: 0; height: 0; }
+  .hangar-toggle-slider { position: absolute; inset: 0; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.15); border-radius: 999px; cursor: pointer; transition: background 0.2s; }
+  .hangar-toggle-slider::before { content: ''; position: absolute; width: 16px; height: 16px; left: 3px; top: 3px; background: rgba(255,255,255,0.7); border-radius: 50%; transition: transform 0.2s, background 0.2s; }
+  .hangar-toggle-switch input:checked + .hangar-toggle-slider { background: rgba(74,222,128,0.35); border-color: #4ade80; }
+  .hangar-toggle-switch input:checked + .hangar-toggle-slider::before { transform: translateX(18px); background: #4ade80; }
+
   /* ── Leaderboard tab ─────────────────────────────────────────── */
   .hangar-lb-tabs { display: flex; gap: 4px; padding: 12px 16px 0; }
   .hangar-lb-tab { flex: 1; padding: 7px 12px; font-family: 'Orbitron', monospace; font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; border: 1px solid rgba(255,255,255,0.12); border-radius: 6px; background: transparent; color: rgba(255,255,255,0.35); cursor: pointer; transition: all 0.15s; }
@@ -2093,6 +2102,17 @@ function renderSettingsView() {
         </div>
         <div class="hangar-theme-hint">Applies to mission HUD and status overlays.</div>
       </div>
+      <div class="hangar-settings-section hangar-accessibility-section">
+        <div class="hangar-settings-label">👁️ Accessibility</div>
+        <div class="hangar-settings-row">
+          <span>High Contrast Mode</span>
+          <label class="hangar-toggle-switch">
+            <input type="checkbox" id="settings-high-contrast" ${localStorage.getItem('voidrift_high_contrast') === '1' ? 'checked' : ''}>
+            <span class="hangar-toggle-slider"></span>
+          </label>
+        </div>
+        <div class="hangar-theme-hint">Boosts contrast and saturation to make enemies, bullets, and pickups easier to distinguish.</div>
+      </div>
     </div>
   `;
 
@@ -2181,6 +2201,15 @@ function renderSettingsView() {
         dailyBtn.disabled = false;
         dailyBtn.textContent = "Start Today's Challenge";
       });
+    });
+  }
+
+  // Wire up High Contrast Mode toggle
+  const highContrastToggle = document.getElementById('settings-high-contrast');
+  if (highContrastToggle) {
+    highContrastToggle.addEventListener('change', () => {
+      localStorage.setItem('voidrift_high_contrast', highContrastToggle.checked ? '1' : '0');
+      if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
     });
   }
 

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2285,6 +2285,8 @@ function switchTab(tab) {
     renderStatsView();
   } else if (tab === 'missions') {
     renderMissionsView();
+  } else if (tab === 'loadout') {
+    renderLoadoutView();
   } else {
     renderUpgradesView();
   }
@@ -2491,6 +2493,151 @@ const RARITY_STYLES = {
     emoji: '⚡',
   },
 };
+
+/**
+ * Render the Loadout tab — configure the 4 equipment slots without needing
+ * to pause a run first. Reads/writes via _options.getLoadout/setLoadout so
+ * the change lands on the same save the in-game pause menu uses; falls back
+ * to a read-only notice if the caller didn't wire those callbacks.
+ */
+const LOADOUT_SLOT_OPTIONS = [
+  {
+    key: 'slot1', label: 'Slot 1 — Primary Weapon (always active)',
+    options: [
+      ['primary:pulse', 'Pulse Blaster'],
+      ['primary:scatter', 'Scatter Coil'],
+      ['primary:rail', 'Rail Lance'],
+      ['primary:ionburst', 'Ion Burst'],
+    ],
+  },
+  {
+    key: 'slot2', label: 'Slot 2 — Secondary Equipment',
+    options: [
+      ['defense:aegis', 'Aegis Shield'],
+      ['defense:reflector', 'Reflector Veil'],
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+      ['boost:boost', 'Boost'],
+    ],
+  },
+  {
+    key: 'slot3', label: 'Slot 3 — Secondary Equipment',
+    options: [
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+      ['defense:aegis', 'Aegis Shield'],
+      ['defense:reflector', 'Reflector Veil'],
+      ['boost:boost', 'Boost'],
+    ],
+  },
+  {
+    key: 'slot4', label: 'Slot 4 — Ultimate / Boost',
+    options: [
+      ['boost:boost', 'Boost'],
+      ['ultimate:voidstorm', 'Voidstorm'],
+      ['ultimate:solarbeam', 'Solar Beam'],
+      ['defense:aegis', 'Aegis Shield'],
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+    ],
+  },
+];
+
+function renderLoadoutView() {
+  const content = document.getElementById('hangarContent');
+  if (!content) return;
+  content.innerHTML = '';
+
+  const equipClass = typeof _options.getLoadout === 'function' ? _options.getLoadout() : null;
+  const canEdit = !!equipClass && typeof _options.setLoadout === 'function';
+
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = 'padding:16px 16px 24px; overflow-y:auto; height:100%; box-sizing:border-box;';
+
+  const hdr = document.createElement('div');
+  hdr.style.cssText = [
+    'font-family:"Orbitron",monospace',
+    'font-size:11px',
+    'font-weight:700',
+    'letter-spacing:0.14em',
+    'color:rgba(255,255,255,0.3)',
+    'text-transform:uppercase',
+    'margin-bottom:14px',
+    'padding-bottom:10px',
+    'border-bottom:1px solid rgba(255,255,255,0.07)',
+  ].join(';');
+  hdr.textContent = 'EQUIPMENT LOADOUT';
+  wrapper.appendChild(hdr);
+
+  if (!canEdit) {
+    const notice = document.createElement('div');
+    notice.style.cssText = 'color:rgba(255,255,255,0.4); font-size:13px; padding:20px 0;';
+    notice.textContent = 'Loadout editing is unavailable right now — configure equipment from the in-game pause menu instead.';
+    wrapper.appendChild(notice);
+    content.appendChild(wrapper);
+    return;
+  }
+
+  const desc = document.createElement('p');
+  desc.style.cssText = 'color:rgba(255,255,255,0.45); font-size:12px; line-height:1.5; margin:0 0 18px;';
+  desc.textContent = 'Configure your 4 equipment slots before launch. Changes apply to your next run.';
+  wrapper.appendChild(desc);
+
+  const form = document.createElement('div');
+  form.style.cssText = 'display:flex; flex-direction:column; gap:14px;';
+
+  LOADOUT_SLOT_OPTIONS.forEach(({ key, label, options }) => {
+    const slotData = equipClass[key] || {};
+    const currentValue = `${slotData.type}:${slotData.id}`;
+
+    const row = document.createElement('label');
+    row.style.cssText = 'display:flex; flex-direction:column; gap:6px;';
+
+    const rowLabel = document.createElement('span');
+    rowLabel.style.cssText = 'font-size:12px; color:rgba(255,255,255,0.6); letter-spacing:0.02em;';
+    rowLabel.textContent = label;
+    row.appendChild(rowLabel);
+
+    const select = document.createElement('select');
+    select.className = 'hangar-loadout-select';
+    select.dataset.slot = key;
+    select.style.cssText = [
+      'background:rgba(255,255,255,0.05)',
+      'border:1px solid rgba(255,255,255,0.12)',
+      'border-radius:8px',
+      'color:#fff',
+      'padding:9px 12px',
+      'font-size:13px',
+      'font-family:inherit',
+    ].join(';');
+    options.forEach(([value, optLabel]) => {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = optLabel;
+      if (value === currentValue) opt.selected = true;
+      select.appendChild(opt);
+    });
+    row.appendChild(select);
+    form.appendChild(row);
+  });
+
+  wrapper.appendChild(form);
+  content.appendChild(wrapper);
+
+  form.addEventListener('change', (e) => {
+    const select = e.target.closest('.hangar-loadout-select');
+    if (!select) return;
+    const [type, id] = select.value.split(':');
+    const updated = { ...equipClass, [select.dataset.slot]: { type, id } };
+    _options.setLoadout(updated);
+  });
+}
 
 /**
  * Render the Fragments tab — shows all 6 tech fragments with collection status,
@@ -2711,6 +2858,7 @@ export function openHangar(opts = {}) {
         <button class="hangar-tab-btn active" data-tab="upgrades">Upgrades</button>
         <button class="hangar-tab-btn" data-tab="skins">Skins</button>
         <button class="hangar-tab-btn" data-tab="missions">Missions</button>
+        <button class="hangar-tab-btn" data-tab="loadout">Loadout</button>
         <button class="hangar-tab-btn" data-tab="achievements">Achievements</button>
         <button class="hangar-tab-btn" data-tab="leaderboard">Leaderboard</button>
         <button class="hangar-tab-btn" data-tab="fragments">Fragments</button>

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1890,6 +1890,8 @@ function renderSettingsView() {
   const sfxVal    = AM ? Math.round(AM.getVolume('sfx')    * 100) : 80;
   const musicVal  = AM ? Math.round(AM.getVolume('music')  * 100) : 50;
   const isMuted   = AM ? AM.getMuted() : false;
+  const shakeStored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+  const shakeVal  = Number.isFinite(shakeStored) ? shakeStored : 100;
 
   content.innerHTML = `
     <div class="hangar-settings">
@@ -1947,6 +1949,17 @@ function renderSettingsView() {
         <div class="hangar-daily-meta" id="hangar-daily-meta"></div>
         <button class="hangar-daily-btn" id="hangar-daily-start-btn">Start Today's Challenge</button>
       </div>
+      <div class="hangar-settings-section">
+        <div class="hangar-settings-label">🎬 Gameplay</div>
+
+        <div class="hangar-settings-row">
+          <span>Screen Shake</span>
+          <input type="range" class="hangar-settings-slider" id="settings-shake-intensity"
+                 min="0" max="150" value="${shakeVal}">
+          <span class="hangar-settings-vol" id="settings-shake-intensity-label">${shakeVal}%</span>
+        </div>
+      </div>
+
       <div class="hangar-settings-section hangar-theme-section">
         <div class="hangar-settings-label">🎨 HUD Theme</div>
         <div class="hangar-theme-swatches" id="hangar-theme-swatches">
@@ -1985,6 +1998,17 @@ function renderSettingsView() {
   wireSlider('settings-master-vol', 'settings-master-vol-label', 'master');
   wireSlider('settings-sfx-vol',    'settings-sfx-vol-label',    'sfx');
   wireSlider('settings-music-vol',  'settings-music-vol-label',  'music');
+
+  // Wire up screen shake intensity slider
+  const shakeSlider = document.getElementById('settings-shake-intensity');
+  const shakeLabel  = document.getElementById('settings-shake-intensity-label');
+  if (shakeSlider) {
+    shakeSlider.addEventListener('input', () => {
+      const val = parseInt(shakeSlider.value, 10);
+      if (shakeLabel) shakeLabel.textContent = `${val}%`;
+      localStorage.setItem('voidrift_screen_shake', String(val));
+    });
+  }
 
   // Wire up mute toggle
   const muteBtn = document.getElementById('settings-mute-btn');

--- a/index.html
+++ b/index.html
@@ -774,6 +774,17 @@
           getSelectedShip: () => {
             return (window.Save && window.Save.data && window.Save.data.selectedShip) || 'vanguard';
           },
+          // Loadout tab reads/writes the same equipment class the in-game
+          // pause menu configures, so changes made here carry into the next run.
+          getLoadout: () => {
+            return (window.Save && window.Save.data && window.Save.data.armory && window.Save.data.armory.equipmentClass) || null;
+          },
+          setLoadout: (equipClass) => {
+            if (!window.Save || !window.Save.data) return;
+            if (!window.Save.data.armory) window.Save.data.armory = {};
+            window.Save.data.armory.equipmentClass = equipClass;
+            window.Save.save();
+          },
           // When a skin is equipped, re-init ship selection so colors update immediately
           onSkinEquip: (shipId, skinId, skin) => {
             if (window.__VOID_RIFT__ && typeof window.__VOID_RIFT__.initShipSelection === 'function') {

--- a/script.js
+++ b/script.js
@@ -4846,6 +4846,10 @@
       baseSpeed *= adaptive.enemySpeedBoost;
       if (isElite) baseSpeed *= ADAPTIVE_CONSTANTS.ELITE_SPEED_MULT;
       if (isBoss) baseSpeed *= ADAPTIVE_CONSTANTS.BOSS_SPEED_MULT; // Bosses are slower but more dangerous
+      // Time Dilation tech fragment: permanent passive enemy slowdown once unlocked
+      if (window.techFragmentSystem && window.techFragmentSystem.hasFragment('chrono_crystal') && window.TECH_UNLOCKS) {
+        baseSpeed *= (1 - (window.TECH_UNLOCKS.time_dilation.stats.enemySlowdown || 0));
+      }
       this.speed = baseSpeed;
       
       // Health scaling with progressive difficulty
@@ -6786,7 +6790,19 @@
       // Bounty target: one per wave from wave 3+, 15% chance on any standard spawn
       if (!bountySpawnedThisWave && level >= 3 && !isElite && kind !== 'shard' && Math.random() < 0.15) {
         const last = enemies[enemies.length - 1];
-        if (last) { last.isBounty = true; last.health = Math.ceil(last.health * 2.5); last.maxHealth = last.health; last.size *= 1.3; bountySpawnedThisWave = true; }
+        if (last) {
+          last.isBounty = true; last.health = Math.ceil(last.health * 2.5); last.maxHealth = last.health; last.size *= 1.3; bountySpawnedThisWave = true;
+          // Give the bounty a named identity from today's active Mission Board bounties, if one is still available
+          if (window.missionSystem) {
+            const namedBounty = window.missionSystem.getActiveBounties().find(b => window.missionSystem.canSpawnBounty(b.id));
+            if (namedBounty) {
+              last.bountyId = namedBounty.id;
+              last.bountyName = namedBounty.name;
+              last.bountyColor = namedBounty.color;
+              window.missionSystem.markBountySpawned(namedBounty.id);
+            }
+          }
+        }
       }
       if (Math.random() < 0.4) this.resetPosition();
     }
@@ -6942,10 +6958,18 @@
       
       // Speed bonuses: keep full benefit for mobility (+ perk multiplier)
       const baseSpeed = BASE.PLAYER_SPEED * shipStat('speed', 1) * perkMultipliers.speed;
-      const boostSpeed = (BASE.PLAYER_BOOST_SPEED + L('boost') * 0.9) * shipStat('boost', shipStat('speed', 1)) * perkMultipliers.speed;
-      
+      const tfs = window.techFragmentSystem;
+      const unlocks = window.TECH_UNLOCKS || {};
+      const quantumDriveMult = (tfs && tfs.hasFragment('quantum_core') && unlocks.quantum_drive)
+        ? unlocks.quantum_drive.stats.boostSpeed : 1;
+      const boostSpeed = (BASE.PLAYER_BOOST_SPEED + L('boost') * 0.9) * shipStat('boost', shipStat('speed', 1)) * perkMultipliers.speed * quantumDriveMult;
+
       // Damage and regen: apply effectiveness modifier
-      const damageMultiplier = (1 + L('damage') * 0.6 * effectiveness);
+      const plasmaOverchargeMult = (tfs && tfs.hasFragment('plasma_cell') && unlocks.plasma_overcharge)
+        ? unlocks.plasma_overcharge.stats.damageBoost : 1;
+      const voidCannonMult = (tfs && tfs.hasFragment('void_shard') && unlocks.void_cannon)
+        ? 1 + (unlocks.void_cannon.stats.damage - 1) * 0.2 : 1; // passive fraction of the full weapon's damage bonus
+      const damageMultiplier = (1 + L('damage') * 0.6 * effectiveness) * plasmaOverchargeMult * voidCannonMult;
       const regenAmount = L('regen') * 3 * effectiveness;
       
       // Repulse field: reduced by both effectiveness and adaptive scaling
@@ -7427,7 +7451,9 @@
 
     addUltimateCharge(amount) {
       if (!amount || amount <= 0) return;
-      this.ultimateCharge = clamp(this.ultimateCharge + amount, 0, this.ultimateChargeMax);
+      const fragmentRate = (window.techFragmentSystem && window.techFragmentSystem.hasFragment('antimatter_vial'))
+        ? (window.TECH_UNLOCKS.antimatter_reactor.stats.ultimateChargeRate || 1) : 1;
+      this.ultimateCharge = clamp(this.ultimateCharge + amount * fragmentRate, 0, this.ultimateChargeMax);
     }
 
     collectSupply(kind) {
@@ -7484,6 +7510,7 @@
       amount *= perkMultipliers.damageTakenMult;
       if (amount <= 0) return;
       tookDamageThisLevel = true;
+      if (window.missionSystem) window.missionSystem.trackDamage(amount);
       this.health -= amount;
       this.flash = true;
       this.invEnd = now + BASE.INVULN_MS + perkMultipliers.invulnBonus;
@@ -8901,6 +8928,7 @@
       dropSupply(enemy.x, enemy.y);
       dropSupply(enemy.x + rand(-40, 40), enemy.y + rand(-40, 40));
       Save.addCredits(250);
+      if (window.missionSystem) window.missionSystem.trackCredits(250);
       leviathanKilledThisRun++;
       // Unlock LEVIATHAN SLAYER achievement
       Auth.playerProfile.leviathanKills = (Auth.playerProfile.leviathanKills || 0) + 1;
@@ -8917,8 +8945,24 @@
       }
       const bountyReward = Math.floor(30 + level * 8);
       Save.addCredits(bountyReward);
+      if (window.missionSystem) window.missionSystem.trackCredits(bountyReward);
       bountyKilledTotal++;
-      addLogEntry(`\u{1F4B0} BOUNTY CLAIMED! +${bountyReward} credits`, '#fbbf24');
+      if (enemy.bountyName) {
+        addLogEntry(`\u{1F4B0} ${enemy.bountyName.toUpperCase()} TAKEN DOWN! +${bountyReward} credits`, '#fbbf24');
+        // Named Mission Board bounties always drop a tech fragment on top of the credit reward
+        if (window.techFragmentSystem) {
+          const bountyFragment = window.techFragmentSystem.rollDrop(true, false) || window.TECH_FRAGMENTS?.[0];
+          if (bountyFragment) {
+            window.techFragmentSystem.collect(bountyFragment.id);
+            if (window.missionSystem) window.missionSystem.trackFragments(1);
+            if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
+              Auth.showTechFragmentNotification(window.techFragmentSystem.getFragmentCount(bountyFragment.id));
+            }
+          }
+        }
+      } else {
+        addLogEntry(`\u{1F4B0} BOUNTY CLAIMED! +${bountyReward} credits`, '#fbbf24');
+      }
       if (typeof AudioManager !== 'undefined' && AudioManager.playCoin) {
         AudioManager.playCoin();
       }
@@ -9078,7 +9122,7 @@
     if (window.missionSystem) {
       const isBoss = !!enemy.isBoss;
       const isElite = !!(enemy.isElite || enemy.type === 'elite');
-      window.missionSystem.trackKill(isBoss, isElite);
+      window.missionSystem.trackKill(isBoss, isElite, enemy.bountyId || null);
       updateMissionHUD();
     }
 
@@ -9113,6 +9157,7 @@
     // Apply kill combo multiplier + Overclock perk score bonus
     const effectiveMultiplier = killComboMultiplier + perkMultipliers.scoreMultBonus;
     scoreGain = Math.round(scoreGain * effectiveMultiplier);
+    if (PowerUps.isOverdriveActive(Date.now())) scoreGain *= 2;
     score += scoreGain;
     if (window.missionSystem) {
       window.missionSystem.trackScore(score);
@@ -9131,6 +9176,7 @@
         // Immediately collect the pickup and show notification (auto-collect on drop)
         pickup.collected = true;
         window.techFragmentSystem.collect(fragment.id);
+        if (window.missionSystem) window.missionSystem.trackFragments(1);
         const count = window.techFragmentSystem.getFragmentCount(fragment.id);
         if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
           Auth.showTechFragmentNotification(count);
@@ -9893,6 +9939,7 @@
       SHIELD: { color: '#22c55e', label: 'SHIELD +30', duration: 0, radius: 10 },
       RAPID:  { color: '#06b6d4', label: 'RAPID FIRE', duration: 8000, radius: 10 },
       NUKE:   { color: '#f97316', label: 'NUKE',       duration: 0, radius: 10 },
+      OVERDRIVE: { color: '#eab308', label: '2X SCORE', duration: 10000, radius: 10 },
     };
     const TYPE_KEYS = Object.keys(TYPES);
     let active = [];       // live pickups on the ground
@@ -9930,6 +9977,9 @@
         effects.push({ type: 'RAPID', endsAt: now + 8000 });
       } else if (type === 'NUKE') {
         nukeAllEnemies();
+      } else if (type === 'OVERDRIVE') {
+        effects = effects.filter(e => e.type !== 'OVERDRIVE');
+        effects.push({ type: 'OVERDRIVE', endsAt: now + 10000 });
       }
     }
 
@@ -9949,6 +9999,10 @@
 
     function isRapidActive(now) {
       return effects.some(e => e.type === 'RAPID' && e.endsAt > now);
+    }
+
+    function isOverdriveActive(now) {
+      return effects.some(e => e.type === 'OVERDRIVE' && e.endsAt > now);
     }
 
     function showPickupBanner(type) {
@@ -9996,9 +10050,19 @@
         ctx.fillText('⚡ RAPID ' + remaining + 's', 12, 110);
         ctx.restore();
       }
+      // Overdrive HUD indicator
+      const overdriveEffect = effects.find(e => e.type === 'OVERDRIVE');
+      if (overdriveEffect) {
+        const remaining = ((overdriveEffect.endsAt - now) / 1000).toFixed(1);
+        ctx.save();
+        ctx.fillStyle = '#eab308'; ctx.font = 'bold 12px monospace';
+        ctx.textAlign = 'left'; ctx.globalAlpha = 0.9;
+        ctx.fillText('★ 2X SCORE ' + remaining + 's', 12, rapidEffect ? 128 : 110);
+        ctx.restore();
+      }
     }
 
-    return { maybeSpawn, update, draw, isRapidActive };
+    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive };
   })();
   // ─── END POWER-UP DROPS ─────────────────────────────────────────────────────
 
@@ -10026,6 +10090,9 @@
     updateComboSystem(); // Phase 1: Update combo timer
     // Power-up pickup collection
     PowerUps.update(player.x, player.y, Date.now());
+    if (window.missionSystem && runStartTime > 0) {
+      window.missionSystem.trackTime(Math.floor((now - runStartTime) / 1000));
+    }
     const targetX = player.x - window.innerWidth / 2;
     const targetY = player.y - window.innerHeight / 2;
     camera.x += (targetX - camera.x) * 0.12;
@@ -10062,18 +10129,28 @@
         const dx = bullet.x - enemy.x;
         const dy = bullet.y - enemy.y;
         if (Math.hypot(dx, dy) < bullet.size + enemy.size) {
-          enemy.health -= bullet.damage;
+          // AI Targeting Matrix tech fragment: chance to crit for bonus damage
+          let hitDamage = bullet.damage;
+          let isCrit = false;
+          if (window.techFragmentSystem && window.techFragmentSystem.hasFragment('neural_chip') && window.TECH_UNLOCKS) {
+            const critStats = window.TECH_UNLOCKS.ai_targeting.stats;
+            if (Math.random() < critStats.critChance) {
+              hitDamage *= critStats.critDamage;
+              isCrit = true;
+            }
+          }
+          enemy.health -= hitDamage;
           runShotsHit++;
           waveShotsHit++;
 
           // Phase 1: Show damage number
-          spawnDamageNumber(enemy.x, enemy.y, bullet.damage, false);
-          
+          spawnDamageNumber(enemy.x, enemy.y, hitDamage, isCrit);
+
           // Phase A.2: Hit flash on damage
           enemy.hitFlash = 150;
-          
+
           addParticles('sparks', bullet.x, bullet.y, 0, 6);
-          if (player) player.addUltimateCharge(bullet.damage * 0.35);
+          if (player) player.addUltimateCharge(hitDamage * 0.35);
           
           // Play hit sound
           if (typeof AudioManager !== 'undefined') {
@@ -10128,6 +10205,7 @@
         coins.splice(i, 1);
         score += 10;
         Save.addCredits(1);
+        if (window.missionSystem) window.missionSystem.trackCredits(1);
         addXP(6);
         
         // Play coin pickup sound
@@ -10154,6 +10232,7 @@
         supplies.splice(i, 1);
         player.collectSupply(crate.kind);
         Save.addCredits(2);
+        if (window.missionSystem) window.missionSystem.trackCredits(2);
         addXP(10);
       }
     }
@@ -10290,6 +10369,10 @@
     Save.addCredits(_creditsBase);
     waveCreditsEarned += _creditsBase;
     addXP(90 + level * 12);
+    if (window.missionSystem) {
+      window.missionSystem.trackCredits(_creditsBase);
+      window.missionSystem.trackLevelComplete(!tookDamageThisLevel);
+    }
     if (!tookDamageThisLevel) {
       addXP(110 + level * 18);
       // Perfect Wave bonus — extra credits + announcement
@@ -10299,6 +10382,7 @@
       // Fixed +50 perfect wave overlay bonus
       Save.addCredits(50);
       waveCreditsEarned += 50;
+      if (window.missionSystem) window.missionSystem.trackCredits(perfectBonus + 50);
       addLogEntry(`🌟 PERFECT WAVE! +${perfectBonus + 50} bonus credits`, '#4ade80');
     }
 
@@ -10321,6 +10405,7 @@
     };
 
     level += 1;
+    if (window.missionSystem) window.missionSystem.trackLevel(level);
     enemiesKilled = 0;
     waveKillCount = 0;
     waveShotsFired = 0;
@@ -10467,6 +10552,7 @@
         () => {
           // onRewarded: add 100 credits
           Save.addCredits(100);
+          if (window.missionSystem) window.missionSystem.trackCredits(100);
           updateHUD();
           addLogEntry('🎬 +100 CR bonus from ad reward!', '#4ade80');
         },
@@ -10581,6 +10667,7 @@
         // Give bonus rewards — tracked for post-wave overlay
         const _bossBonus = level * 50;
         Save.addCredits(_bossBonus);
+        if (window.missionSystem) window.missionSystem.trackCredits(_bossBonus);
         addXP(level * 100);
         advanceLevel();
         waveCreditsEarned += _bossBonus; // add boss bonus after advanceLevel resets counter
@@ -10991,7 +11078,7 @@
         ctx.shadowBlur = 12;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'top';
-        ctx.fillText('⚠ WANTED TARGET', canvas.width - 16, 56);
+        ctx.fillText(aliveBounty.bountyName ? `⚠ WANTED: ${aliveBounty.bountyName.toUpperCase()}` : '⚠ WANTED TARGET', canvas.width - 16, 56);
         ctx.restore();
       }
     }
@@ -12058,7 +12145,9 @@
   const handleGameOver = () => {
     gameOverHandled = true;
     Save.setBest(score, level);
-    Save.addCredits(Math.floor(score / 25));
+    const _finalCashOut = Math.floor(score / 25);
+    Save.addCredits(_finalCashOut);
+    if (window.missionSystem) window.missionSystem.trackCredits(_finalCashOut);
 
     // Local leaderboard — check before saving so isPersonalBest is accurate
     const isNewBest = LocalLeaderboard.isPersonalBest(score);
@@ -12154,6 +12243,15 @@
       showGameOverScreen(finalScore, finalLevel, null, isNewBest, runKillCount, runTimeSec, runAccuracyPct);
     }
   };
+
+  // ── Accessibility ────────────────────────────────────────────────────────
+  function applyHighContrast() {
+    const enabled = localStorage.getItem('voidrift_high_contrast') === '1';
+    if (dom.canvas) {
+      dom.canvas.style.filter = enabled ? 'contrast(1.35) saturate(1.5) brightness(1.05)' : '';
+    }
+  }
+  window.applyHighContrast = applyHighContrast;
 
   // ── Mission HUD ─────────────────────────────────────────────────────────
   function getHudAccent() {
@@ -12664,6 +12762,7 @@
   
   const ready = () => {
     assignDomRefs();
+    applyHighContrast();
     Save.load();
     Auth.load();
     Leaderboard.load();

--- a/script.js
+++ b/script.js
@@ -873,6 +873,7 @@
   let pilotLevel = 1;
   let pilotXP = 0;
   let tookDamageThisLevel = false;
+  let lastCloseCallAt = 0;
   let gameOverHandled = false;
   let continueUsed = false;
   let runShotsFired = 0;
@@ -1339,6 +1340,45 @@
       el.style.opacity = '0';
       setTimeout(() => el.remove(), 400);
     }, 2200);
+  };
+  // Close Call bonus — brief flash when an enemy bullet grazes the player without hitting
+  const CLOSE_CALL_MARGIN = 16;    // px beyond the hit radius that counts as a graze
+  const CLOSE_CALL_COOLDOWN = 600; // ms between rewards, so a bullet stream can't spam it
+  const CLOSE_CALL_CREDITS = 2;
+  const CLOSE_CALL_SCORE = 15;
+
+  const showCloseCallFlash = () => {
+    const existing = document.getElementById('closeCallBanner');
+    if (existing) existing.remove();
+
+    const el = document.createElement('div');
+    el.id = 'closeCallBanner';
+    el.style.cssText = [
+      'position:fixed',
+      'top:16%',
+      'left:50%',
+      'transform:translate(-50%,-50%)',
+      'color:#38bdf8',
+      'font-size:15px',
+      'font-weight:700',
+      'letter-spacing:.08em',
+      'text-transform:uppercase',
+      'text-shadow:0 0 10px rgba(56,189,248,.8)',
+      'pointer-events:none',
+      'z-index:998',
+      'opacity:1',
+      'transition:opacity 0.5s, transform 0.5s',
+    ].join(';');
+    el.textContent = `⚡ CLOSE CALL! +${CLOSE_CALL_SCORE}`;
+    document.body.appendChild(el);
+
+    requestAnimationFrame(() => {
+      el.style.transform = 'translate(-50%,-70%)';
+    });
+    setTimeout(() => {
+      el.style.opacity = '0';
+      setTimeout(() => el.remove(), 500);
+    }, 500);
   };
   // ── END PERK SYSTEM ───────────────────────────────────────────────────────
 
@@ -2221,6 +2261,7 @@
     pilotLevel = Save.data.pilotLevel;
     pilotXP = Save.data.pilotXp;
     tookDamageThisLevel = false;
+    lastCloseCallAt = 0;
     gameOverHandled = false;
     continueUsed = false;
     if (window.missionSystem) { window.missionSystem.startRun(); updateMissionHUD(); }
@@ -10265,6 +10306,16 @@
         const adaptive = getAdaptiveScaling();
         const source = { shieldPenetration: adaptive.shieldPenetration * ADAPTIVE_CONSTANTS.BULLET_PENETRATION_FACTOR };
         player.takeDamage(bullet.damage, source);
+      } else if (
+        !bullet.nearMissCounted &&
+        dist < player.size + bullet.size + CLOSE_CALL_MARGIN &&
+        now - lastCloseCallAt > CLOSE_CALL_COOLDOWN
+      ) {
+        bullet.nearMissCounted = true;
+        lastCloseCallAt = now;
+        score += CLOSE_CALL_SCORE;
+        Save.addCredits(CLOSE_CALL_CREDITS);
+        showCloseCallFlash();
       }
     }
 

--- a/script.js
+++ b/script.js
@@ -843,6 +843,8 @@
   let powerSurges = [];          // active Power Surge orbs on screen
   let medicOrbs = [];             // active Medic Orb pickups on screen
   let ghostOrbs = [];             // active Ghost Orb pickups — grant 3s invincibility
+  let freezeOrbs = [];           // active Freeze Orb pickups — slow all enemies 60% for 3s
+  let freezeExpiry = 0;          // timestamp when freeze effect ends
   let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
   let surgeExpiry = 0;           // timestamp when current boost ends
   let spawners = [];
@@ -2209,6 +2211,8 @@
     powerSurges = [];
     medicOrbs = [];
     ghostOrbs = [];
+    freezeOrbs = [];
+    freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -8993,6 +8997,10 @@
     if ((wasElite || enemy.isWanted) && Math.random() < 0.03) {
       ghostOrbs.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 11000 });
     }
+    // Freeze Orb drop (4% chance, not on shards — slows all enemies 60% for 3s)
+    if (enemy.kind !== 'shard' && Math.random() < 0.04) {
+      freezeOrbs.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 12000 });
+    }
 
     // Phase A.4: Enhanced death effects based on enemy type
     const deathColor = wasLeviathan ? '#FF2020' :
@@ -10315,6 +10323,41 @@
       }
     }
 
+    // Freeze Orbs
+    for (let i = freezeOrbs.length - 1; i >= 0; i--) {
+      const orb = freezeOrbs[i];
+      if (now - orb.created > orb.life) { freezeOrbs.splice(i, 1); continue; }
+      const dx = player.x - orb.x;
+      const dy = player.y - orb.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist > 220) {
+        orb.x += (dx / (dist || 1)) * 1.1;
+        orb.y += (dy / (dist || 1)) * 1.1;
+      }
+      if (dist < player.size + orb.r) {
+        freezeOrbs.splice(i, 1);
+        // Slow all active enemies — store pre-freeze speed
+        for (const e of enemies) {
+          if (!e._preFreezeSpeed) e._preFreezeSpeed = e.speed;
+          e.speed = (e._preFreezeSpeed) * 0.4;
+        }
+        freezeExpiry = now + 3000;
+        addLogEntry('❄️ FREEZE ORB! Enemies slowed 3s', '#93c5fd');
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+      }
+    }
+    // Expire freeze
+    if (freezeExpiry > 0 && now >= freezeExpiry) {
+      for (const e of enemies) {
+        if (e._preFreezeSpeed !== undefined) {
+          e.speed = e._preFreezeSpeed;
+          delete e._preFreezeSpeed;
+        }
+      }
+      freezeExpiry = 0;
+      addLogEntry('Freeze ended', '#6b7280');
+    }
+
     for (const obstacle of obstacles) obstacle.update(dt);
 
     // Update environmental hazards
@@ -10532,6 +10575,8 @@
     powerSurges = [];
     medicOrbs = [];
     ghostOrbs = [];
+    freezeOrbs = [];
+    freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -10869,6 +10914,52 @@
       ctx.lineTo(orb.x - 4.5, orb.y + 4);
       ctx.closePath();
       ctx.fill();
+      ctx.restore();
+    }
+    // Draw Freeze Orbs
+    for (const orb of freezeOrbs) {
+      const _t = performance.now();
+      const pulse = 0.7 + 0.3 * Math.sin((_t / 280) + orb.created);
+      ctx.save();
+      ctx.globalAlpha = 0.92;
+      const grad = ctx.createRadialGradient(orb.x, orb.y, 0, orb.x, orb.y, orb.r * 2.2 * pulse);
+      grad.addColorStop(0, '#e0f2fe');
+      grad.addColorStop(0.4, '#38bdf8');
+      grad.addColorStop(0.75, '#0284c7');
+      grad.addColorStop(1, 'rgba(2,132,199,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * 2.2 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      // Outer ring
+      ctx.strokeStyle = 'rgba(186,230,253,0.8)';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * pulse, 0, Math.PI * 2);
+      ctx.stroke();
+      // Snowflake — 6 spokes from center
+      ctx.strokeStyle = 'rgba(255,255,255,0.92)';
+      ctx.lineWidth = 1.5;
+      ctx.lineCap = 'round';
+      for (let a = 0; a < 6; a++) {
+        const angle = (a * Math.PI) / 3;
+        ctx.beginPath();
+        ctx.moveTo(orb.x, orb.y);
+        ctx.lineTo(orb.x + Math.cos(angle) * 5, orb.y + Math.sin(angle) * 5);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    // Freeze active overlay — blue tint vignette on screen edges
+    if (freezeExpiry > 0) {
+      const remaining = (freezeExpiry - performance.now()) / 3000;
+      const alpha = Math.max(0, remaining * 0.18);
+      const vg = ctx.createRadialGradient(canvas.width / 2, canvas.height / 2, canvas.height * 0.3, canvas.width / 2, canvas.height / 2, canvas.height * 0.85);
+      vg.addColorStop(0, 'rgba(56,189,248,0)');
+      vg.addColorStop(1, `rgba(56,189,248,${alpha.toFixed(3)})`);
+      ctx.save();
+      ctx.fillStyle = vg;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
       ctx.restore();
     }
     for (const bullet of bullets) bullet.draw(ctx);

--- a/script.js
+++ b/script.js
@@ -1347,6 +1347,7 @@
   let comboTimer = 0;
   const COMBO_TIMEOUT = 2500; // ms - time between kills to maintain combo
   let totalKillsThisRun = 0;
+  let peakComboThisRun = 0;
 
   // Kill Combo Multiplier System
   let killComboMultiplier = 1;       // Current score multiplier (1–5)
@@ -2262,6 +2263,7 @@
     comboCount = 0;
     comboTimer = 0;
     totalKillsThisRun = 0;
+    peakComboThisRun = 0;
     lastKillStreakNotification = 0;
     runShotsFired = 0;
     runShotsHit = 0;
@@ -2468,6 +2470,7 @@
     comboCount++;
     comboTimer = now + COMBO_TIMEOUT;
     totalKillsThisRun++;
+    peakComboThisRun = Math.max(peakComboThisRun, comboCount);
     
     // Check for kill streak milestones
     for (const milestone of KILL_STREAK_MILESTONES) {
@@ -11996,7 +11999,18 @@
       playTime: performance.now() - (waveStartTime || performance.now()),
       flawlessLevel: !tookDamageThisLevel
     });
-    
+
+    // Feed the AchievementSystem lifetime totals so the Hangar's Achievements
+    // and Stats tabs (which read voidrift_achievements) actually update.
+    if (typeof window.updateAchievementStats === 'function') {
+      window.updateAchievementStats({
+        totalKills: Auth.playerProfile.totalKills,
+        maxWave: level,
+        bossKills: Auth.playerProfile.bossKills,
+        maxCombo: peakComboThisRun
+      });
+    }
+
     // Stop game and show game over screen
     gameRunning = false;
     paused = false;
@@ -12034,12 +12048,9 @@
         try {
           const completedCount = getTotalDailyChallengesCompleted();
           const streak = getDailyStreak();
-          import('./src/systems/AchievementSystem.js').then(({ updateStats }) => {
-            const newlyUnlocked = updateStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
-            if (newlyUnlocked && newlyUnlocked.length > 0 && typeof showAchievementToast === 'function') {
-              newlyUnlocked.forEach(ach => showAchievementToast(ach));
-            }
-          }).catch(err => console.warn('[DailyChallenge] Achievement update failed:', err));
+          if (typeof window.updateAchievementStats === 'function') {
+            window.updateAchievementStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
+          }
         } catch (e) {
           console.warn('[DailyChallenge] Achievement stats error:', e);
         }

--- a/script.js
+++ b/script.js
@@ -6480,8 +6480,9 @@
       const nx = movementX + ax;
       const ny = movementY + ay;
       const nm = Math.hypot(nx, ny) || 1;
-      this.x += (nx / nm) * this.speed * (dt / 16.67);
-      this.y += (ny / nm) * this.speed * (dt / 16.67);
+      const slowMoMult = PowerUps.enemySpeedMultiplier(Date.now());
+      this.x += (nx / nm) * this.speed * slowMoMult * (dt / 16.67);
+      this.y += (ny / nm) * this.speed * slowMoMult * (dt / 16.67);
       // Snipers lock rotation to aim angle during telegraph; otherwise face player
       if (this.kind === 'sniper' && (this.sniperPhase === 'aiming' || this.sniperPhase === 'cooldown')) {
         this.rot = this.sniperAimAngle;
@@ -9879,7 +9880,10 @@
       SHIELD: { color: '#22c55e', label: 'SHIELD +30', duration: 0, radius: 10 },
       RAPID:  { color: '#06b6d4', label: 'RAPID FIRE', duration: 8000, radius: 10 },
       NUKE:   { color: '#f97316', label: 'NUKE',       duration: 0, radius: 10 },
+      MAGNET: { color: '#eab308', label: 'MAGNET',     duration: 10000, radius: 10 },
+      SLOWMO: { color: '#a855f7', label: 'SLOW-MO',    duration: 6000, radius: 10 },
     };
+    const SLOWMO_SPEED_MULT = 0.45;
     const TYPE_KEYS = Object.keys(TYPES);
     let active = [];       // live pickups on the ground
     let effects = [];      // active timed effects {type, endsAt}
@@ -9916,6 +9920,12 @@
         effects.push({ type: 'RAPID', endsAt: now + 8000 });
       } else if (type === 'NUKE') {
         nukeAllEnemies();
+      } else if (type === 'MAGNET') {
+        effects = effects.filter(e => e.type !== 'MAGNET');
+        effects.push({ type: 'MAGNET', endsAt: now + TYPES.MAGNET.duration });
+      } else if (type === 'SLOWMO') {
+        effects = effects.filter(e => e.type !== 'SLOWMO');
+        effects.push({ type: 'SLOWMO', endsAt: now + TYPES.SLOWMO.duration });
       }
     }
 
@@ -9935,6 +9945,14 @@
 
     function isRapidActive(now) {
       return effects.some(e => e.type === 'RAPID' && e.endsAt > now);
+    }
+
+    function isMagnetActive(now) {
+      return effects.some(e => e.type === 'MAGNET' && e.endsAt > now);
+    }
+
+    function enemySpeedMultiplier(now) {
+      return effects.some(e => e.type === 'SLOWMO' && e.endsAt > now) ? SLOWMO_SPEED_MULT : 1;
     }
 
     function showPickupBanner(type) {
@@ -9972,19 +9990,27 @@
         ctx.fillText(p.type, p.x, p.y + 24);
         ctx.restore();
       });
-      // Rapid fire HUD indicator
-      const rapidEffect = effects.find(e => e.type === 'RAPID');
-      if (rapidEffect) {
-        const remaining = ((rapidEffect.endsAt - now) / 1000).toFixed(1);
+      // Timed-effect HUD indicators
+      const hudEffects = [
+        { type: 'RAPID',  icon: '⚡', color: '#06b6d4' },
+        { type: 'MAGNET', icon: '🧲', color: '#eab308' },
+        { type: 'SLOWMO', icon: '🐢', color: '#a855f7' },
+      ];
+      let hudY = 110;
+      hudEffects.forEach(({ type, icon, color }) => {
+        const effect = effects.find(e => e.type === type);
+        if (!effect) return;
+        const remaining = ((effect.endsAt - now) / 1000).toFixed(1);
         ctx.save();
-        ctx.fillStyle = '#06b6d4'; ctx.font = 'bold 12px monospace';
+        ctx.fillStyle = color; ctx.font = 'bold 12px monospace';
         ctx.textAlign = 'left'; ctx.globalAlpha = 0.9;
-        ctx.fillText('⚡ RAPID ' + remaining + 's', 12, 110);
+        ctx.fillText(`${icon} ${TYPES[type].label} ${remaining}s`, 12, hudY);
         ctx.restore();
-      }
+        hudY += 18;
+      });
     }
 
-    return { maybeSpawn, update, draw, isRapidActive };
+    return { maybeSpawn, update, draw, isRapidActive, isMagnetActive, enemySpeedMultiplier };
   })();
   // ─── END POWER-UP DROPS ─────────────────────────────────────────────────────
 
@@ -10102,7 +10128,8 @@
         coins.splice(i, 1);
         continue;
       }
-      const pickupRadius = player ? player.size + 80 : 120;
+      const magnetActive = PowerUps.isMagnetActive(now);
+      const pickupRadius = (player ? player.size + 80 : 120) * (magnetActive ? 6 : 1);
       const dx = player.x - coin.x;
       const dy = player.y - coin.y;
       const dist = Math.hypot(dx, dy);

--- a/script.js
+++ b/script.js
@@ -840,6 +840,9 @@
   let bullets = [];
   let coins = [];
   let supplies = [];
+  let powerSurges = [];          // active Power Surge orbs on screen
+  let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
+  let surgeExpiry = 0;           // timestamp when current boost ends
   let spawners = [];
   let starsFar = null;
   let starsMid = null;
@@ -2201,6 +2204,9 @@
     bullets = [];
     coins = [];
     supplies = [];
+    powerSurges = [];
+    surgeDamageMultiplier = 1;
+    surgeExpiry = 0;
     spawners = [];
     particles = [];
     obstacles = [];
@@ -7269,7 +7275,7 @@
         const speed = BASE.BULLET_SPEED * (weaponStats.bulletSpeed || 1) * perkMultipliers.bulletSpeed;
         const size = BASE.BULLET_SIZE * (weaponStats.bulletSize || 1);
         const pierce = (weaponStats.pierce || 0) + perkMultipliers.piercePlus;
-        const dmg = stats.dmg * perkMultipliers.damage;
+        const dmg = stats.dmg * perkMultipliers.damage * surgeDamageMultiplier;
         bullets.push(new Bullet(sx, sy, vel, dmg, color, speed, size, pierce));
         runShotsFired++;
         waveShotsFired++;
@@ -8927,7 +8933,11 @@
     } else if (!wasLeviathan && chance(wasElite ? 0.5 : 0.22)) {
       dropSupply(enemy.x, enemy.y);
     }
-    
+    // Power Surge orb drop (6% chance, not on shards)
+    if (enemy.kind !== 'shard' && Math.random() < 0.06) {
+      powerSurges.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 12000 });
+    }
+
     // Phase A.4: Enhanced death effects based on enemy type
     const deathColor = wasLeviathan ? '#FF2020' :
                        wasBoss ? '#7c3aed' :
@@ -10148,6 +10158,32 @@
       }
     }
 
+    // Power Surge orbs
+    for (let i = powerSurges.length - 1; i >= 0; i--) {
+      const orb = powerSurges[i];
+      if (now - orb.created > orb.life) { powerSurges.splice(i, 1); continue; }
+      const dx = player.x - orb.x;
+      const dy = player.y - orb.y;
+      const dist = Math.hypot(dx, dy);
+      // Gentle attraction when close
+      if (dist < 140) {
+        orb.x += (dx / (dist || 1)) * 1.2;
+        orb.y += (dy / (dist || 1)) * 1.2;
+      }
+      if (dist < player.size + orb.r) {
+        powerSurges.splice(i, 1);
+        surgeDamageMultiplier = 1.8;
+        surgeExpiry = now + 8000;
+        addLogEntry('⚡ POWER SURGE! 1.8× DMG for 8s', '#a855f7');
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+      }
+    }
+    // Expire surge
+    if (surgeDamageMultiplier > 1 && now > surgeExpiry) {
+      surgeDamageMultiplier = 1;
+      addLogEntry('Power Surge ended', '#6b7280');
+    }
+
     for (const obstacle of obstacles) obstacle.update(dt);
 
     // Update environmental hazards
@@ -10356,6 +10392,9 @@
     bullets = [];
     coins = [];
     supplies = [];
+    powerSurges = [];
+    surgeDamageMultiplier = 1;
+    surgeExpiry = 0;
     spawners = [];
     particles = [];
     bossActive = false;
@@ -10613,6 +10652,22 @@
     for (const spawner of spawners) spawner.draw(ctx);
     for (const coin of coins) coin.draw(ctx);
     for (const supply of supplies) supply.draw(ctx);
+    // Draw Power Surge orbs
+    for (const orb of powerSurges) {
+      const _t = performance.now();
+      const pulse = 0.7 + 0.3 * Math.sin((_t / 250) + orb.created);
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      const grad = ctx.createRadialGradient(orb.x, orb.y, 0, orb.x, orb.y, orb.r * 2 * pulse);
+      grad.addColorStop(0, '#e879f9');
+      grad.addColorStop(0.5, '#a855f7');
+      grad.addColorStop(1, 'rgba(168,85,247,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * 2 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
     for (const bullet of bullets) bullet.draw(ctx);
     for (const enemy of enemies) enemy.draw(ctx);
     
@@ -10747,6 +10802,22 @@
           killComboEscalated = false;
         }
       }
+    }
+
+    // ── Power Surge HUD indicator ────────────────────────────────────────────
+    if (surgeDamageMultiplier > 1 && now < surgeExpiry) {
+      const remaining = (surgeExpiry - now) / 8000;
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      ctx.fillStyle = '#a855f7';
+      ctx.fillRect(16, canvas.height - 56, 120 * remaining, 6);
+      ctx.strokeStyle = '#7c3aed';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(16, canvas.height - 56, 120, 6);
+      ctx.fillStyle = '#e879f9';
+      ctx.font = 'bold 10px Arial';
+      ctx.fillText('⚡ SURGE', 16, canvas.height - 62);
+      ctx.restore();
     }
 
     // ── Combo Timer DOM HUD (live depleting progress bar) ───────────────────

--- a/script.js
+++ b/script.js
@@ -844,6 +844,9 @@
   let medicOrbs = [];             // active Medic Orb pickups on screen
   let ghostOrbs = [];             // active Ghost Orb pickups — grant 3s invincibility
   let freezeOrbs = [];           // active Freeze Orb pickups — slow all enemies 60% for 3s
+  let lightningOrbs = [];        // active Lightning Orb pickups — chain lightning to up to 3 enemies
+  let lightningArcs = [];        // transient arc visuals [ {pts:[{x,y},...], expiry} ]
+  let lightningFlashEnd = 0;     // timestamp when electric screen flash fades out
   let freezeExpiry = 0;          // timestamp when freeze effect ends
   let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
   let surgeExpiry = 0;           // timestamp when current boost ends
@@ -9001,6 +9004,10 @@
     if (enemy.kind !== 'shard' && Math.random() < 0.04) {
       freezeOrbs.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 12000 });
     }
+    // Lightning Orb drop (3.5% chance, not on shards — chain lightning to up to 3 enemies)
+    if (enemy.kind !== 'shard' && Math.random() < 0.035) {
+      lightningOrbs.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 7000 });
+    }
 
     // Phase A.4: Enhanced death effects based on enemy type
     const deathColor = wasLeviathan ? '#FF2020' :
@@ -10358,6 +10365,70 @@
       addLogEntry('Freeze ended', '#6b7280');
     }
 
+    // Lightning Orbs
+    for (let i = lightningOrbs.length - 1; i >= 0; i--) {
+      const orb = lightningOrbs[i];
+      if (now - orb.created > orb.life) { lightningOrbs.splice(i, 1); continue; }
+      const dx = player.x - orb.x;
+      const dy = player.y - orb.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist < 150) {
+        orb.x += (dx / (dist || 1)) * 1.2;
+        orb.y += (dy / (dist || 1)) * 1.2;
+      }
+      if (dist < player.size + orb.r) {
+        lightningOrbs.splice(i, 1);
+        // Chain lightning: sort live enemies by distance from player
+        const sorted = enemies
+          .map((e, idx) => ({ e, idx, d: Math.hypot(e.x - player.x, e.y - player.y) }))
+          .sort((a, b) => a.d - b.d);
+        const arcPts = [{ x: player.x, y: player.y }];
+        let hitCount = 0;
+        let lastX = player.x, lastY = player.y;
+        // Hit primary target (45 dmg)
+        if (sorted.length > 0) {
+          const primary = sorted[0];
+          const prev = primary.e.health;
+          primary.e.health -= 45;
+          primary.e.hitFlash = 200;
+          spawnDamageNumber(primary.e.x, primary.e.y, Math.min(prev, 45), false);
+          addParticles('sparks', primary.e.x, primary.e.y, 0, 14);
+          arcPts.push({ x: primary.e.x, y: primary.e.y });
+          if (primary.e.health <= 0) handleEnemyDeath(primary.idx, 0);
+          lastX = primary.e.x; lastY = primary.e.y;
+          hitCount++;
+          // Chain to up to 2 more within 180px of the primary hit
+          let chainCount = 0;
+          for (let j = 1; j < sorted.length && chainCount < 2; j++) {
+            const chain = sorted[j];
+            const chainDist = Math.hypot(chain.e.x - lastX, chain.e.y - lastY);
+            if (chainDist > 180) continue;
+            const prev2 = chain.e.health;
+            chain.e.health -= 22;
+            chain.e.hitFlash = 160;
+            spawnDamageNumber(chain.e.x, chain.e.y, Math.min(prev2, 22), false);
+            addParticles('sparks', chain.e.x, chain.e.y, 0, 8);
+            arcPts.push({ x: chain.e.x, y: chain.e.y });
+            // Re-find index in case array shifted from prior handleEnemyDeath
+            const liveIdx = enemies.indexOf(chain.e);
+            if (chain.e.health <= 0 && liveIdx >= 0) handleEnemyDeath(liveIdx, 0);
+            lastX = chain.e.x; lastY = chain.e.y;
+            chainCount++;
+          }
+        }
+        // Store arc for rendering
+        if (arcPts.length > 1) {
+          lightningArcs.push({ pts: arcPts, expiry: now + 350 });
+        }
+        // Electric screen flash
+        lightningFlashEnd = now + 120;
+        addLogEntry('⚡ CHAIN LIGHTNING', '#facc15');
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+      }
+    }
+    // Expire lightning arcs
+    lightningArcs = lightningArcs.filter(a => now < a.expiry);
+
     for (const obstacle of obstacles) obstacle.update(dt);
 
     // Update environmental hazards
@@ -10950,6 +11021,81 @@
       }
       ctx.restore();
     }
+    // Draw Lightning Orbs
+    for (const orb of lightningOrbs) {
+      const _t = performance.now();
+      const pulse = 0.65 + 0.35 * Math.sin((_t / 200) + orb.created);
+      ctx.save();
+      ctx.globalAlpha = 0.93;
+      const grad = ctx.createRadialGradient(orb.x, orb.y, 0, orb.x, orb.y, orb.r * 2.3 * pulse);
+      grad.addColorStop(0, '#ffffff');
+      grad.addColorStop(0.35, '#facc15');
+      grad.addColorStop(0.7, '#ca8a04');
+      grad.addColorStop(1, 'rgba(250,204,21,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * 2.3 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      // Outer ring
+      ctx.strokeStyle = 'rgba(255,255,180,0.75)';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * pulse, 0, Math.PI * 2);
+      ctx.stroke();
+      // Lightning bolt glyph — Z-shape (top-center → mid-right → mid-left → bottom-center)
+      ctx.strokeStyle = 'rgba(255,255,255,0.95)';
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
+      ctx.moveTo(orb.x,     orb.y - 5.5);   // top center
+      ctx.lineTo(orb.x + 3, orb.y - 0.5);   // mid right
+      ctx.lineTo(orb.x - 3, orb.y + 0.5);   // mid left
+      ctx.lineTo(orb.x,     orb.y + 5.5);   // bottom center
+      ctx.stroke();
+      ctx.restore();
+    }
+    // Draw lightning arcs (chain lightning visual)
+    const _nowArc = performance.now();
+    for (const arc of lightningArcs) {
+      const frac = 1 - (_nowArc - (_nowArc - (arc.expiry - _nowArc))) / 350;
+      const alpha = Math.max(0, (arc.expiry - _nowArc) / 350);
+      ctx.save();
+      ctx.globalAlpha = alpha * 0.85;
+      ctx.strokeStyle = '#facc15';
+      ctx.lineWidth = 2.5;
+      ctx.lineCap = 'round';
+      ctx.shadowColor = '#ffffff';
+      ctx.shadowBlur = 8;
+      ctx.beginPath();
+      ctx.moveTo(arc.pts[0].x, arc.pts[0].y);
+      for (let p = 1; p < arc.pts.length; p++) {
+        ctx.lineTo(arc.pts[p].x, arc.pts[p].y);
+      }
+      ctx.stroke();
+      // White inner arc for glow
+      ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+      ctx.lineWidth = 1;
+      ctx.shadowBlur = 0;
+      ctx.beginPath();
+      ctx.moveTo(arc.pts[0].x, arc.pts[0].y);
+      for (let p = 1; p < arc.pts.length; p++) {
+        ctx.lineTo(arc.pts[p].x, arc.pts[p].y);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+    // Electric screen flash
+    if (lightningFlashEnd > 0 && _nowArc < lightningFlashEnd) {
+      const flashFrac = (_nowArc - (lightningFlashEnd - 120)) / 120;
+      const flashAlpha = 0.15 * (1 - Math.min(1, flashFrac));
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, flashAlpha);
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.restore();
+    }
+
     // Freeze active overlay — blue tint vignette on screen edges
     if (freezeExpiry > 0) {
       const remaining = (freezeExpiry - performance.now()) / 3000;

--- a/script.js
+++ b/script.js
@@ -842,6 +842,7 @@
   let supplies = [];
   let powerSurges = [];          // active Power Surge orbs on screen
   let medicOrbs = [];             // active Medic Orb pickups on screen
+  let ghostOrbs = [];             // active Ghost Orb pickups — grant 3s invincibility
   let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
   let surgeExpiry = 0;           // timestamp when current boost ends
   let spawners = [];
@@ -2207,6 +2208,7 @@
     supplies = [];
     powerSurges = [];
     medicOrbs = [];
+    ghostOrbs = [];
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -8987,6 +8989,10 @@
     if (enemy.kind !== 'shard' && player && player.health < (player.hpMax || 100) * 0.6 && chance(0.04)) {
       medicOrbs.push({ x: enemy.x, y: enemy.y, r: 9, created: performance.now(), life: 10000 });
     }
+    // Ghost Orb drop (3% chance from elite or WANTED enemies only — rare, high-value)
+    if ((wasElite || enemy.isWanted) && Math.random() < 0.03) {
+      ghostOrbs.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 11000 });
+    }
 
     // Phase A.4: Enhanced death effects based on enemy type
     const deathColor = wasLeviathan ? '#FF2020' :
@@ -10290,6 +10296,25 @@
       }
     }
 
+    // Ghost Orbs
+    for (let i = ghostOrbs.length - 1; i >= 0; i--) {
+      const orb = ghostOrbs[i];
+      if (now - orb.created > orb.life) { ghostOrbs.splice(i, 1); continue; }
+      const dx = player.x - orb.x;
+      const dy = player.y - orb.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist < 130) {
+        orb.x += (dx / (dist || 1)) * 1.3;
+        orb.y += (dy / (dist || 1)) * 1.3;
+      }
+      if (dist < player.size + orb.r) {
+        ghostOrbs.splice(i, 1);
+        player.invEnd = now + 3000;
+        addLogEntry('👻 GHOST ORB! 3s invincibility', '#67e8f9');
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+      }
+    }
+
     for (const obstacle of obstacles) obstacle.update(dt);
 
     // Update environmental hazards
@@ -10506,6 +10531,7 @@
     supplies = [];
     powerSurges = [];
     medicOrbs = [];
+    ghostOrbs = [];
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -10811,9 +10837,43 @@
       ctx.stroke();
       ctx.restore();
     }
+    // Draw Ghost Orbs
+    for (const orb of ghostOrbs) {
+      const _t = performance.now();
+      const pulse = 0.65 + 0.35 * Math.sin((_t / 220) + orb.created);
+      ctx.save();
+      ctx.globalAlpha = 0.88;
+      const grad = ctx.createRadialGradient(orb.x, orb.y, 0, orb.x, orb.y, orb.r * 2.4 * pulse);
+      grad.addColorStop(0, '#e0f7ff');
+      grad.addColorStop(0.4, '#67e8f9');
+      grad.addColorStop(0.75, '#0891b2');
+      grad.addColorStop(1, 'rgba(8,145,178,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * 2.4 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      // Draw ghost "G" shimmer ring
+      ctx.strokeStyle = 'rgba(255,255,255,0.7)';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * pulse, 0, Math.PI * 2);
+      ctx.stroke();
+      // Draw ghost symbol (simple spirit shape: arc top + flat bottom)
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y - 1, 4.5, Math.PI, 0, false);
+      ctx.lineTo(orb.x + 4.5, orb.y + 4);
+      ctx.lineTo(orb.x + 1.5, orb.y + 2.5);
+      ctx.lineTo(orb.x, orb.y + 4);
+      ctx.lineTo(orb.x - 1.5, orb.y + 2.5);
+      ctx.lineTo(orb.x - 4.5, orb.y + 4);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
     for (const bullet of bullets) bullet.draw(ctx);
     for (const enemy of enemies) enemy.draw(ctx);
-    
+
     // Phase 1: Draw enemy health bars
     for (const enemy of enemies) {
       if (enemy.health < enemy.maxHealth) {

--- a/script.js
+++ b/script.js
@@ -841,6 +841,7 @@
   let coins = [];
   let supplies = [];
   let powerSurges = [];          // active Power Surge orbs on screen
+  let medicOrbs = [];             // active Medic Orb pickups on screen
   let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
   let surgeExpiry = 0;           // timestamp when current boost ends
   let spawners = [];
@@ -2205,6 +2206,7 @@
     coins = [];
     supplies = [];
     powerSurges = [];
+    medicOrbs = [];
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -8981,6 +8983,10 @@
     if (enemy.kind !== 'shard' && Math.random() < 0.06) {
       powerSurges.push({ x: enemy.x, y: enemy.y, r: 10, created: performance.now(), life: 12000 });
     }
+    // Medic Orb drop (4% chance, not on shards, only if player below 60% HP)
+    if (enemy.kind !== 'shard' && player && player.health < (player.hpMax || 100) * 0.6 && chance(0.04)) {
+      medicOrbs.push({ x: enemy.x, y: enemy.y, r: 9, created: performance.now(), life: 10000 });
+    }
 
     // Phase A.4: Enhanced death effects based on enemy type
     const deathColor = wasLeviathan ? '#FF2020' :
@@ -10263,6 +10269,27 @@
       addLogEntry('Power Surge ended', '#6b7280');
     }
 
+    // Medic Orbs
+    for (let i = medicOrbs.length - 1; i >= 0; i--) {
+      const orb = medicOrbs[i];
+      if (now - orb.created > orb.life) { medicOrbs.splice(i, 1); continue; }
+      const dx = player.x - orb.x;
+      const dy = player.y - orb.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist < 120) {
+        orb.x += (dx / (dist || 1)) * 1.4;
+        orb.y += (dy / (dist || 1)) * 1.4;
+      }
+      if (dist < player.size + orb.r) {
+        medicOrbs.splice(i, 1);
+        const hpMax = player.hpMax || 100;
+        const healAmt = Math.min(20, hpMax - player.health);
+        player.health = Math.min(hpMax, player.health + healAmt);
+        addLogEntry(`❤️ Medic Orb +${healAmt} HP`, '#4ade80');
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+      }
+    }
+
     for (const obstacle of obstacles) obstacle.update(dt);
 
     // Update environmental hazards
@@ -10478,6 +10505,7 @@
     coins = [];
     supplies = [];
     powerSurges = [];
+    medicOrbs = [];
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     spawners = [];
@@ -10753,6 +10781,34 @@
       ctx.beginPath();
       ctx.arc(orb.x, orb.y, orb.r * 2 * pulse, 0, Math.PI * 2);
       ctx.fill();
+      ctx.restore();
+    }
+    // Draw Medic Orbs
+    for (const orb of medicOrbs) {
+      const _t = performance.now();
+      const pulse = 0.7 + 0.3 * Math.sin((_t / 300) + orb.created);
+      ctx.save();
+      ctx.globalAlpha = 0.92;
+      const grad = ctx.createRadialGradient(orb.x, orb.y, 0, orb.x, orb.y, orb.r * 2.2 * pulse);
+      grad.addColorStop(0, '#86efac');
+      grad.addColorStop(0.45, '#4ade80');
+      grad.addColorStop(1, 'rgba(74,222,128,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(orb.x, orb.y, orb.r * 2.2 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      // Draw cross symbol
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 2.5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(orb.x, orb.y - 5);
+      ctx.lineTo(orb.x, orb.y + 5);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(orb.x - 5, orb.y);
+      ctx.lineTo(orb.x + 5, orb.y);
+      ctx.stroke();
       ctx.restore();
     }
     for (const bullet of bullets) bullet.draw(ctx);

--- a/script.js
+++ b/script.js
@@ -2362,9 +2362,16 @@
     }
   };
 
+  const getShakeIntensity = () => {
+    const stored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+    return (Number.isFinite(stored) ? stored : 100) / 100;
+  };
+
   const shakeScreen = (power = 4, duration = 120) => {
+    const scaledPower = power * getShakeIntensity();
+    if (scaledPower <= 0) return;
     shakeUntil = Math.max(shakeUntil, performance.now() + duration);
-    shakePower = power;
+    shakePower = scaledPower;
   };
 
   // ── Special Ability: fire the Q-key ability for the current ship ───────────

--- a/script.js
+++ b/script.js
@@ -1667,6 +1667,9 @@
       this.save();
     }
   };
+  // Expose on window: the start-screen Hangar entry point (index.html) bridges
+  // credits/ship-selection/loadout callbacks through window.Save.
+  window.Save = Save;
 
   const costOf = (upgrade) => {
     const lvl = Save.getUpgradeLevel(upgrade.id);
@@ -9410,7 +9413,20 @@
     // Also update radial menu icons if it exists
     updateRadialMenuIcons();
   };
-  
+
+  // Open the Hangar overlay wired to the live save, so its Loadout tab can
+  // read/write the same equipment class the in-game pause menu configures.
+  const openHangarOverlay = () => {
+    openHangar({
+      getLoadout: () => Save.data.armory.equipmentClass || defaultArmory().equipmentClass,
+      setLoadout: (equipClass) => {
+        Save.data.armory.equipmentClass = equipClass;
+        Save.save();
+        updateEquipmentIndicator();
+      }
+    });
+  };
+
   // Update radial menu icons to match equipment loadout
   const updateRadialMenuIcons = () => {
     const radialMenu = document.getElementById('radialMenu');
@@ -13674,7 +13690,7 @@
     });
     document.getElementById('pauseHangarBtn')?.addEventListener('click', () => {
       hidePauseMenu();
-      openHangar();
+      openHangarOverlay();
     });
     document.getElementById('pauseLeaderboardBtn')?.addEventListener('click', () => {
       hidePauseMenu();
@@ -13697,7 +13713,7 @@
       closeGameOverScreen();
       dom.gameContainer.style.display = 'none';
       dom.startScreen.style.display = 'flex';
-      openHangar();
+      openHangarOverlay();
     });
     document.getElementById('gameOverLeaderboardBtn')?.addEventListener('click', () => {
       closeGameOverScreen();
@@ -13773,7 +13789,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangar();
+      openHangarOverlay();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {
@@ -13931,7 +13947,7 @@
     
     document.getElementById('menuHangarBtn')?.addEventListener('click', () => {
       closeUnifiedMenu();
-      openHangar();
+      openHangarOverlay();
     });
     
     document.getElementById('menuLeaderboardBtn')?.addEventListener('click', () => {
@@ -14041,7 +14057,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangar();
+      openHangarOverlay();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

Five small, self-contained improvements continuing the daily Void Rift improvement loop. No prior "5 tasks" list was found anywhere retrievable (no cron job, repo file, or GitHub issue/PR persisted one), so these were selected by surveying the codebase for real gaps and natural next features, matching the scope of recent commits like Perfect Wave bonus and the Missions/Stats/Fragments Hangar tabs.

- **fix: wire AchievementSystem to gameplay** — The Achievements tab and Stats tab both read from `voidrift_achievements`, but nothing in `script.js` ever populated `totalKills`/`maxWave`/`bossKills`/`maxCombo`. The only live caller only ever passed daily-challenge fields, and its toast check referenced a name (`showAchievementToast`) that doesn't exist in that scope. `handleGameOver` now reports lifetime stats after every run, so achievements actually unlock and the Stats tab shows real numbers.
- **feat: MAGNET and SLOW-MO power-ups** — Two new timed pickups alongside SHIELD/RAPID/NUKE: MAGNET pulls coins in from 6x range for 10s, SLOW-MO cuts enemy speed to 45% for 6s. Both get HUD countdown indicators.
- **feat: screen shake intensity slider** — 0–150% slider in Hangar Settings (persisted to `voidrift_screen_shake`) that scales every `shakeScreen()` call for comfort/preference.
- **feat: Close Call bonus** — +15 score / +2 credits with a brief HUD flash when an enemy bullet grazes the player (within 16px) without hitting, cooldown-gated so a bullet stream can't farm it. Mirrors the existing Perfect Wave bonus pattern.
- **feat: Loadout tab in Hangar** — Configure the 4 equipment slots from the main menu instead of needing to pause a run first. Along the way, fixed a dead bridge: the start-screen Hangar entry point reads/writes state through `window.Save`, but `script.js` never exposed `Save` on `window`, so `getCredits`/`spendCredits`/`getSelectedShip` (and the new loadout callbacks) always silently fell back to defaults. Added `window.Save = Save` so all of these work as originally intended.

## Test plan

- [x] `node --check` on all modified files
- [x] `npx jest` — 175/175 tests pass (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox)
- [x] Playwright smoke test: opened Hangar from start screen, verified Loadout tab renders all 4 selects with correct defaults, changed a slot and confirmed it persists to `localStorage['void_rift_v11'].armory.equipmentClass`
- [x] Playwright smoke test: called `window.updateAchievementStats(...)` directly and confirmed it returns newly-unlocked achievements and renders a `.hangar-toast` element
- [x] Verified Settings tab renders the new Screen Shake slider
- [ ] Manual playtest of MAGNET/SLOW-MO pickups and Close Call bonus in a live run (not exercised beyond code review — recommend a quick playthrough before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ChQaTQNywBPsRURy8ZFu7C)_