### PR TITLE
Daily improvement loop: wire dead mission/fragment systems, named bounties, OVERDRIVE power-up, high-contrast mode

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1237,6 +1237,15 @@ const HANGAR_UI_CSS = `
   .hangar-theme-swatch.active { border-color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.3); transform: scale(1.1); }
   .hangar-theme-hint { font-size: 11px; color: rgba(255,255,255,0.35); margin-top: 8px; }
 
+  /* ── Accessibility section ───────────────────────────────── */
+  .hangar-accessibility-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
+  .hangar-toggle-switch { position: relative; display: inline-block; width: 42px; height: 24px; flex-shrink: 0; }
+  .hangar-toggle-switch input { opacity: 0; width: 0; height: 0; }
+  .hangar-toggle-slider { position: absolute; inset: 0; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.15); border-radius: 999px; cursor: pointer; transition: background 0.2s; }
+  .hangar-toggle-slider::before { content: ''; position: absolute; width: 16px; height: 16px; left: 3px; top: 3px; background: rgba(255,255,255,0.7); border-radius: 50%; transition: transform 0.2s, background 0.2s; }
+  .hangar-toggle-switch input:checked + .hangar-toggle-slider { background: rgba(74,222,128,0.35); border-color: #4ade80; }
+  .hangar-toggle-switch input:checked + .hangar-toggle-slider::before { transform: translateX(18px); background: #4ade80; }
+
   /* ── Leaderboard tab ─────────────────────────────────────────── */
   .hangar-lb-tabs { display: flex; gap: 4px; padding: 12px 16px 0; }
   .hangar-lb-tab { flex: 1; padding: 7px 12px; font-family: 'Orbitron', monospace; font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; border: 1px solid rgba(255,255,255,0.12); border-radius: 6px; background: transparent; color: rgba(255,255,255,0.35); cursor: pointer; transition: all 0.15s; }
@@ -2093,6 +2102,17 @@ function renderSettingsView() {
         </div>
         <div class="hangar-theme-hint">Applies to mission HUD and status overlays.</div>
       </div>
+      <div class="hangar-settings-section hangar-accessibility-section">
+        <div class="hangar-settings-label">👁️ Accessibility</div>
+        <div class="hangar-settings-row">
+          <span>High Contrast Mode</span>
+          <label class="hangar-toggle-switch">
+            <input type="checkbox" id="settings-high-contrast" ${localStorage.getItem('voidrift_high_contrast') === '1' ? 'checked' : ''}>
+            <span class="hangar-toggle-slider"></span>
+          </label>
+        </div>
+        <div class="hangar-theme-hint">Boosts contrast and saturation to make enemies, bullets, and pickups easier to distinguish.</div>
+      </div>
     </div>
   `;
 
@@ -2181,6 +2201,15 @@ function renderSettingsView() {
         dailyBtn.disabled = false;
         dailyBtn.textContent = "Start Today's Challenge";
       });
+    });
+  }
+
+  // Wire up High Contrast Mode toggle
+  const highContrastToggle = document.getElementById('settings-high-contrast');
+  if (highContrastToggle) {
+    highContrastToggle.addEventListener('change', () => {
+      localStorage.setItem('voidrift_high_contrast', highContrastToggle.checked ? '1' : '0');
+      if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
     });
   }
 

--- a/script.js
+++ b/script.js
@@ -4840,6 +4840,10 @@
       baseSpeed *= adaptive.enemySpeedBoost;
       if (isElite) baseSpeed *= ADAPTIVE_CONSTANTS.ELITE_SPEED_MULT;
       if (isBoss) baseSpeed *= ADAPTIVE_CONSTANTS.BOSS_SPEED_MULT; // Bosses are slower but more dangerous
+      // Time Dilation tech fragment: permanent passive enemy slowdown once unlocked
+      if (window.techFragmentSystem && window.techFragmentSystem.hasFragment('chrono_crystal') && window.TECH_UNLOCKS) {
+        baseSpeed *= (1 - (window.TECH_UNLOCKS.time_dilation.stats.enemySlowdown || 0));
+      }
       this.speed = baseSpeed;
       
       // Health scaling with progressive difficulty
@@ -6780,7 +6784,19 @@
       // Bounty target: one per wave from wave 3+, 15% chance on any standard spawn
       if (!bountySpawnedThisWave && level >= 3 && !isElite && kind !== 'shard' && Math.random() < 0.15) {
         const last = enemies[enemies.length - 1];
-        if (last) { last.isBounty = true; last.health = Math.ceil(last.health * 2.5); last.maxHealth = last.health; last.size *= 1.3; bountySpawnedThisWave = true; }
+        if (last) {
+          last.isBounty = true; last.health = Math.ceil(last.health * 2.5); last.maxHealth = last.health; last.size *= 1.3; bountySpawnedThisWave = true;
+          // Give the bounty a named identity from today's active Mission Board bounties, if one is still available
+          if (window.missionSystem) {
+            const namedBounty = window.missionSystem.getActiveBounties().find(b => window.missionSystem.canSpawnBounty(b.id));
+            if (namedBounty) {
+              last.bountyId = namedBounty.id;
+              last.bountyName = namedBounty.name;
+              last.bountyColor = namedBounty.color;
+              window.missionSystem.markBountySpawned(namedBounty.id);
+            }
+          }
+        }
       }
       if (Math.random() < 0.4) this.resetPosition();
     }
@@ -6936,10 +6952,18 @@
       
       // Speed bonuses: keep full benefit for mobility (+ perk multiplier)
       const baseSpeed = BASE.PLAYER_SPEED * shipStat('speed', 1) * perkMultipliers.speed;
-      const boostSpeed = (BASE.PLAYER_BOOST_SPEED + L('boost') * 0.9) * shipStat('boost', shipStat('speed', 1)) * perkMultipliers.speed;
-      
+      const tfs = window.techFragmentSystem;
+      const unlocks = window.TECH_UNLOCKS || {};
+      const quantumDriveMult = (tfs && tfs.hasFragment('quantum_core') && unlocks.quantum_drive)
+        ? unlocks.quantum_drive.stats.boostSpeed : 1;
+      const boostSpeed = (BASE.PLAYER_BOOST_SPEED + L('boost') * 0.9) * shipStat('boost', shipStat('speed', 1)) * perkMultipliers.speed * quantumDriveMult;
+
       // Damage and regen: apply effectiveness modifier
-      const damageMultiplier = (1 + L('damage') * 0.6 * effectiveness);
+      const plasmaOverchargeMult = (tfs && tfs.hasFragment('plasma_cell') && unlocks.plasma_overcharge)
+        ? unlocks.plasma_overcharge.stats.damageBoost : 1;
+      const voidCannonMult = (tfs && tfs.hasFragment('void_shard') && unlocks.void_cannon)
+        ? 1 + (unlocks.void_cannon.stats.damage - 1) * 0.2 : 1; // passive fraction of the full weapon's damage bonus
+      const damageMultiplier = (1 + L('damage') * 0.6 * effectiveness) * plasmaOverchargeMult * voidCannonMult;
       const regenAmount = L('regen') * 3 * effectiveness;
       
       // Repulse field: reduced by both effectiveness and adaptive scaling
@@ -7421,7 +7445,9 @@
 
     addUltimateCharge(amount) {
       if (!amount || amount <= 0) return;
-      this.ultimateCharge = clamp(this.ultimateCharge + amount, 0, this.ultimateChargeMax);
+      const fragmentRate = (window.techFragmentSystem && window.techFragmentSystem.hasFragment('antimatter_vial'))
+        ? (window.TECH_UNLOCKS.antimatter_reactor.stats.ultimateChargeRate || 1) : 1;
+      this.ultimateCharge = clamp(this.ultimateCharge + amount * fragmentRate, 0, this.ultimateChargeMax);
     }
 
     collectSupply(kind) {
@@ -7478,6 +7504,7 @@
       amount *= perkMultipliers.damageTakenMult;
       if (amount <= 0) return;
       tookDamageThisLevel = true;
+      if (window.missionSystem) window.missionSystem.trackDamage(amount);
       this.health -= amount;
       this.flash = true;
       this.invEnd = now + BASE.INVULN_MS + perkMultipliers.invulnBonus;
@@ -8895,6 +8922,7 @@
       dropSupply(enemy.x, enemy.y);
       dropSupply(enemy.x + rand(-40, 40), enemy.y + rand(-40, 40));
       Save.addCredits(250);
+      if (window.missionSystem) window.missionSystem.trackCredits(250);
       leviathanKilledThisRun++;
       // Unlock LEVIATHAN SLAYER achievement
       Auth.playerProfile.leviathanKills = (Auth.playerProfile.leviathanKills || 0) + 1;
@@ -8911,8 +8939,24 @@
       }
       const bountyReward = Math.floor(30 + level * 8);
       Save.addCredits(bountyReward);
+      if (window.missionSystem) window.missionSystem.trackCredits(bountyReward);
       bountyKilledTotal++;
-      addLogEntry(`\u{1F4B0} BOUNTY CLAIMED! +${bountyReward} credits`, '#fbbf24');
+      if (enemy.bountyName) {
+        addLogEntry(`\u{1F4B0} ${enemy.bountyName.toUpperCase()} TAKEN DOWN! +${bountyReward} credits`, '#fbbf24');
+        // Named Mission Board bounties always drop a tech fragment on top of the credit reward
+        if (window.techFragmentSystem) {
+          const bountyFragment = window.techFragmentSystem.rollDrop(true, false) || window.TECH_FRAGMENTS?.[0];
+          if (bountyFragment) {
+            window.techFragmentSystem.collect(bountyFragment.id);
+            if (window.missionSystem) window.missionSystem.trackFragments(1);
+            if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
+              Auth.showTechFragmentNotification(window.techFragmentSystem.getFragmentCount(bountyFragment.id));
+            }
+          }
+        }
+      } else {
+        addLogEntry(`\u{1F4B0} BOUNTY CLAIMED! +${bountyReward} credits`, '#fbbf24');
+      }
       if (typeof AudioManager !== 'undefined' && AudioManager.playCoin) {
         AudioManager.playCoin();
       }
@@ -9068,7 +9112,7 @@
     if (window.missionSystem) {
       const isBoss = !!enemy.isBoss;
       const isElite = !!(enemy.isElite || enemy.type === 'elite');
-      window.missionSystem.trackKill(isBoss, isElite);
+      window.missionSystem.trackKill(isBoss, isElite, enemy.bountyId || null);
       updateMissionHUD();
     }
 
@@ -9103,6 +9147,7 @@
     // Apply kill combo multiplier + Overclock perk score bonus
     const effectiveMultiplier = killComboMultiplier + perkMultipliers.scoreMultBonus;
     scoreGain = Math.round(scoreGain * effectiveMultiplier);
+    if (PowerUps.isOverdriveActive(Date.now())) scoreGain *= 2;
     score += scoreGain;
     if (window.missionSystem) {
       window.missionSystem.trackScore(score);
@@ -9121,6 +9166,7 @@
         // Immediately collect the pickup and show notification (auto-collect on drop)
         pickup.collected = true;
         window.techFragmentSystem.collect(fragment.id);
+        if (window.missionSystem) window.missionSystem.trackFragments(1);
         const count = window.techFragmentSystem.getFragmentCount(fragment.id);
         if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
           Auth.showTechFragmentNotification(count);
@@ -9883,6 +9929,7 @@
       SHIELD: { color: '#22c55e', label: 'SHIELD +30', duration: 0, radius: 10 },
       RAPID:  { color: '#06b6d4', label: 'RAPID FIRE', duration: 8000, radius: 10 },
       NUKE:   { color: '#f97316', label: 'NUKE',       duration: 0, radius: 10 },
+      OVERDRIVE: { color: '#eab308', label: '2X SCORE', duration: 10000, radius: 10 },
     };
     const TYPE_KEYS = Object.keys(TYPES);
     let active = [];       // live pickups on the ground
@@ -9920,6 +9967,9 @@
         effects.push({ type: 'RAPID', endsAt: now + 8000 });
       } else if (type === 'NUKE') {
         nukeAllEnemies();
+      } else if (type === 'OVERDRIVE') {
+        effects = effects.filter(e => e.type !== 'OVERDRIVE');
+        effects.push({ type: 'OVERDRIVE', endsAt: now + 10000 });
       }
     }
 
@@ -9939,6 +9989,10 @@
 
     function isRapidActive(now) {
       return effects.some(e => e.type === 'RAPID' && e.endsAt > now);
+    }
+
+    function isOverdriveActive(now) {
+      return effects.some(e => e.type === 'OVERDRIVE' && e.endsAt > now);
     }
 
     function showPickupBanner(type) {
@@ -9986,9 +10040,19 @@
         ctx.fillText('⚡ RAPID ' + remaining + 's', 12, 110);
         ctx.restore();
       }
+      // Overdrive HUD indicator
+      const overdriveEffect = effects.find(e => e.type === 'OVERDRIVE');
+      if (overdriveEffect) {
+        const remaining = ((overdriveEffect.endsAt - now) / 1000).toFixed(1);
+        ctx.save();
+        ctx.fillStyle = '#eab308'; ctx.font = 'bold 12px monospace';
+        ctx.textAlign = 'left'; ctx.globalAlpha = 0.9;
+        ctx.fillText('★ 2X SCORE ' + remaining + 's', 12, rapidEffect ? 128 : 110);
+        ctx.restore();
+      }
     }
 
-    return { maybeSpawn, update, draw, isRapidActive };
+    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive };
   })();
   // ─── END POWER-UP DROPS ─────────────────────────────────────────────────────
 
@@ -10016,6 +10080,9 @@
     updateComboSystem(); // Phase 1: Update combo timer
     // Power-up pickup collection
     PowerUps.update(player.x, player.y, Date.now());
+    if (window.missionSystem && runStartTime > 0) {
+      window.missionSystem.trackTime(Math.floor((now - runStartTime) / 1000));
+    }
     const targetX = player.x - window.innerWidth / 2;
     const targetY = player.y - window.innerHeight / 2;
     camera.x += (targetX - camera.x) * 0.12;
@@ -10052,18 +10119,28 @@
         const dx = bullet.x - enemy.x;
         const dy = bullet.y - enemy.y;
         if (Math.hypot(dx, dy) < bullet.size + enemy.size) {
-          enemy.health -= bullet.damage;
+          // AI Targeting Matrix tech fragment: chance to crit for bonus damage
+          let hitDamage = bullet.damage;
+          let isCrit = false;
+          if (window.techFragmentSystem && window.techFragmentSystem.hasFragment('neural_chip') && window.TECH_UNLOCKS) {
+            const critStats = window.TECH_UNLOCKS.ai_targeting.stats;
+            if (Math.random() < critStats.critChance) {
+              hitDamage *= critStats.critDamage;
+              isCrit = true;
+            }
+          }
+          enemy.health -= hitDamage;
           runShotsHit++;
           waveShotsHit++;
 
           // Phase 1: Show damage number
-          spawnDamageNumber(enemy.x, enemy.y, bullet.damage, false);
-          
+          spawnDamageNumber(enemy.x, enemy.y, hitDamage, isCrit);
+
           // Phase A.2: Hit flash on damage
           enemy.hitFlash = 150;
-          
+
           addParticles('sparks', bullet.x, bullet.y, 0, 6);
-          if (player) player.addUltimateCharge(bullet.damage * 0.35);
+          if (player) player.addUltimateCharge(hitDamage * 0.35);
           
           // Play hit sound
           if (typeof AudioManager !== 'undefined') {
@@ -10118,6 +10195,7 @@
         coins.splice(i, 1);
         score += 10;
         Save.addCredits(1);
+        if (window.missionSystem) window.missionSystem.trackCredits(1);
         addXP(6);
         
         // Play coin pickup sound
@@ -10144,6 +10222,7 @@
         supplies.splice(i, 1);
         player.collectSupply(crate.kind);
         Save.addCredits(2);
+        if (window.missionSystem) window.missionSystem.trackCredits(2);
         addXP(10);
       }
     }
@@ -10254,6 +10333,10 @@
     Save.addCredits(_creditsBase);
     waveCreditsEarned += _creditsBase;
     addXP(90 + level * 12);
+    if (window.missionSystem) {
+      window.missionSystem.trackCredits(_creditsBase);
+      window.missionSystem.trackLevelComplete(!tookDamageThisLevel);
+    }
     if (!tookDamageThisLevel) {
       addXP(110 + level * 18);
       // Perfect Wave bonus — extra credits + announcement
@@ -10263,6 +10346,7 @@
       // Fixed +50 perfect wave overlay bonus
       Save.addCredits(50);
       waveCreditsEarned += 50;
+      if (window.missionSystem) window.missionSystem.trackCredits(perfectBonus + 50);
       addLogEntry(`🌟 PERFECT WAVE! +${perfectBonus + 50} bonus credits`, '#4ade80');
     }
 
@@ -10285,6 +10369,7 @@
     };
 
     level += 1;
+    if (window.missionSystem) window.missionSystem.trackLevel(level);
     enemiesKilled = 0;
     waveKillCount = 0;
     waveShotsFired = 0;
@@ -10428,6 +10513,7 @@
         () => {
           // onRewarded: add 100 credits
           Save.addCredits(100);
+          if (window.missionSystem) window.missionSystem.trackCredits(100);
           updateHUD();
           addLogEntry('🎬 +100 CR bonus from ad reward!', '#4ade80');
         },
@@ -10542,6 +10628,7 @@
         // Give bonus rewards — tracked for post-wave overlay
         const _bossBonus = level * 50;
         Save.addCredits(_bossBonus);
+        if (window.missionSystem) window.missionSystem.trackCredits(_bossBonus);
         addXP(level * 100);
         advanceLevel();
         waveCreditsEarned += _bossBonus; // add boss bonus after advanceLevel resets counter
@@ -10920,7 +11007,7 @@
         ctx.shadowBlur = 12;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'top';
-        ctx.fillText('⚠ WANTED TARGET', canvas.width - 16, 56);
+        ctx.fillText(aliveBounty.bountyName ? `⚠ WANTED: ${aliveBounty.bountyName.toUpperCase()}` : '⚠ WANTED TARGET', canvas.width - 16, 56);
         ctx.restore();
       }
     }
@@ -11987,7 +12074,9 @@
   const handleGameOver = () => {
     gameOverHandled = true;
     Save.setBest(score, level);
-    Save.addCredits(Math.floor(score / 25));
+    const _finalCashOut = Math.floor(score / 25);
+    Save.addCredits(_finalCashOut);
+    if (window.missionSystem) window.missionSystem.trackCredits(_finalCashOut);
 
     // Local leaderboard — check before saving so isPersonalBest is accurate
     const isNewBest = LocalLeaderboard.isPersonalBest(score);
@@ -12083,6 +12172,15 @@
       showGameOverScreen(finalScore, finalLevel, null, isNewBest, runKillCount, runTimeSec, runAccuracyPct);
     }
   };
+
+  // ── Accessibility ────────────────────────────────────────────────────────
+  function applyHighContrast() {
+    const enabled = localStorage.getItem('voidrift_high_contrast') === '1';
+    if (dom.canvas) {
+      dom.canvas.style.filter = enabled ? 'contrast(1.35) saturate(1.5) brightness(1.05)' : '';
+    }
+  }
+  window.applyHighContrast = applyHighContrast;
 
   // ── Mission HUD ─────────────────────────────────────────────────────────
   function getHudAccent() {
@@ -12593,6 +12691,7 @@
   
   const ready = () => {
     assignDomRefs();
+    applyHighContrast();
     Save.load();
     Auth.load();
     Leaderboard.load();


### PR DESCRIPTION
## Summary

Five small, self-contained improvements continuing the daily Void Rift improvement loop. As with the prior loop's PR #125, no persisted "5 tasks" list was found anywhere retrievable (checked scheduled cron jobs, repo files, and GitHub issues/PRs — the only related history is PR #125's own unmerged daily-loop PR), so these were selected by surveying the codebase for real gaps.

- **fix: wire MissionSystem's dead progress trackers** — Only `trackKill` and `trackScore` were ever called from `script.js`. `trackCredits`, `trackFragments`, `trackLevel`, `trackDamage`, `trackLevelComplete`, and `trackTime` were fully implemented but never invoked, so any `COLLECT_CREDITS`, `COLLECT_FRAGMENTS`, `REACH_LEVEL`, `NO_DAMAGE_LEVEL`, or `SURVIVE_TIME` daily mission could never progress or complete. Wired each tracker at its real gameplay event (coin/crate pickups, wave-complete credit bonuses, level-up, damage taken, fragment collection, per-frame elapsed time).
- **feat: named Bounty Targets** — The existing WANTED bounty enemy (gold crown, 2.5× HP, one per wave from level 3+) now draws its identity from `MissionSystem`'s previously-unused `BOUNTY_TARGETS` list (Crimson Ace, Void Phantom, Iron Warlord, Swarm Queen, Quantum Hunter) — shown in the HUD and kill log, plus a guaranteed tech fragment reward. This also wires `canSpawnBounty` / `markBountySpawned` / `trackKill`'s `bountyId` param, so `completedBounties` tracking (previously dead) actually populates.
- **feat: Tech Fragment unlocks now affect gameplay** — Previously the 6 legendary fragment unlocks (`TECH_UNLOCKS`) were display-only flavor text in the Fragments tab. Now: Quantum Core boosts boost-speed, Plasma Cell + Void Shard boost damage, Neural Chip adds a crit chance/damage roll on bullet hits (reusing the existing-but-unused `isCrit` damage-number styling), Antimatter Vial speeds ultimate charge, Chrono Crystal slows enemy speed.
- **feat: OVERDRIVE power-up** — New timed 2× score multiplier pickup alongside the existing SHIELD/RAPID/NUKE drops, following the same pattern as RAPID's timed effect.
- **feat: High Contrast Mode** — New accessibility toggle in Hangar Settings that boosts canvas contrast/saturation to make enemies, bullets, and pickups easier to distinguish; persisted to `localStorage` and applied on load.

## Test plan

- [x] `node --check` on both modified files
- [x] `npx jest` — 175/175 tests pass (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox)
- [x] `eslint` — identical 24 errors / 21 warnings before and after this change (all pre-existing, none introduced)
- [x] Playwright smoke test: opened the Hangar, verified the Settings tab renders the High Contrast toggle; toggling it sets `localStorage['voidrift_high_contrast']` and applies/removes the canvas filter; Missions and Fragments tabs render correctly with zero console errors
- [x] Playwright smoke test: started a live run, confirmed `missionSystem.getRunStats()` updates (`timeElapsed`) over 4s of play with zero page errors
- [ ] Manual playtest of the named bounty flow, OVERDRIVE pickup, and tech fragment gameplay bonuses in a full run (verified via code review + automated checks; recommend a quick playthrough before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5p1NhSs5qrK5EPWJpAjrA

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5p1NhSs5qrK5EPWJpAjrA)_