### PR TITLE
Daily improvement loop: Elite Destroyer fix, Temporal Rift/Supernova ultimate effects, Overcharge Matrix boost, missions nav badge

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2879,6 +2879,7 @@ function renderFragmentsView() {
   };
 
   const totalCollected = allFragments.filter(f => getCount(f.id) > 0).length;
+  const isComplete = !!(sys && typeof sys.isCollectionComplete === 'function' && sys.isCollectionComplete());
 
   const wrapper = document.createElement('div');
   wrapper.className = 'hangar-fragments';
@@ -2890,7 +2891,9 @@ function renderFragmentsView() {
     TECH FRAGMENTS &nbsp;
     <span>${totalCollected} / ${allFragments.length} discovered</span>
     <span style="flex:1"></span>
-    <span style="font-size:10px;color:rgba(255,255,255,0.28);font-style:italic">Drop from Elites &amp; Bosses</span>
+    ${isComplete
+      ? `<span style="font-size:10px;color:#c084fc;font-weight:700;letter-spacing:0.05em;">&#9733; COLLECTION COMPLETE</span>`
+      : `<span style="font-size:10px;color:rgba(255,255,255,0.28);font-style:italic">Drop from Elites &amp; Bosses</span>`}
   `;
   wrapper.appendChild(hdr);
 

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1143,6 +1143,25 @@ const HANGAR_UI_CSS = `
   .hangar-mission-claim-btn.claimed-label { background: rgba(255,255,255,0.07); color: rgba(255,255,255,0.3); cursor: default; }
   .hangar-missions-empty { padding: 40px 16px; text-align: center; color: rgba(255,255,255,0.25); font-size: 12px; }
 
+  /* ── Active Bounties (in Missions tab) ─────────────────────── */
+  .hangar-bounties-header { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: rgba(255,255,255,0.35); margin: 18px 0 10px; }
+  .hangar-bounty-card {
+    border-radius: 10px; padding: 12px 16px;
+    border: 1px solid var(--bounty-color, rgba(251,191,36,0.3));
+    background: rgba(255,255,255,0.03);
+    display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    margin-bottom: 8px;
+  }
+  .hangar-bounty-name { font-size: 12px; font-weight: 700; color: var(--bounty-color, #fbbf24); letter-spacing: -0.01em; }
+  .hangar-bounty-desc { font-size: 10px; color: rgba(255,255,255,0.4); margin-top: 2px; line-height: 1.4; }
+  .hangar-bounty-difficulty { font-size: 9px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: rgba(255,255,255,0.45); margin-top: 4px; }
+  .hangar-bounty-reward {
+    flex-shrink: 0; display: flex; flex-direction: column; align-items: flex-end; gap: 2px;
+    font-size: 11px; font-family: 'Orbitron', monospace; font-weight: 700;
+    color: #fbbf24; white-space: nowrap;
+  }
+  .hangar-bounty-reward .frag-tag { font-size: 9px; color: #c084fc; }
+
   /* ── Fragments tab ─────────────────────────────────────────── */
   .hangar-fragments { padding: 16px; }
   .hangar-fragments-header { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: rgba(255,255,255,0.35); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
@@ -2538,11 +2557,41 @@ function renderMissionsView() {
   `;
   wrapper.appendChild(hdr);
 
+  // Active named Bounty Targets — preview today's WANTED enemies before running into one.
+  // Rendered regardless of daily-mission state, appended after the mission list below.
+  const bounties = ms ? ms.getActiveBounties() : [];
+  const appendBounties = () => {
+    if (bounties.length === 0) return;
+    const bountiesHdr = document.createElement('div');
+    bountiesHdr.className = 'hangar-bounties-header';
+    bountiesHdr.textContent = 'Active Bounties';
+    wrapper.appendChild(bountiesHdr);
+
+    bounties.forEach(bounty => {
+      const card = document.createElement('div');
+      card.className = 'hangar-bounty-card';
+      card.style.setProperty('--bounty-color', bounty.color || '#fbbf24');
+      card.innerHTML = `
+        <div>
+          <div class="hangar-bounty-name">⚠ ${bounty.name}</div>
+          <div class="hangar-bounty-desc">${bounty.desc}</div>
+          <div class="hangar-bounty-difficulty">${(bounty.difficulty || '').replace('_', ' ')}</div>
+        </div>
+        <div class="hangar-bounty-reward">
+          ⚡ ${bounty.reward} CR
+          ${bounty.techFragment ? '<span class="frag-tag">+ Fragment</span>' : ''}
+        </div>
+      `;
+      wrapper.appendChild(card);
+    });
+  };
+
   if (!ms || missions.length === 0) {
     const empty = document.createElement('div');
     empty.className = 'hangar-missions-empty';
     empty.innerHTML = `<div style="font-size:28px;margin-bottom:8px">📋</div>No missions loaded yet.<br>Start a game to generate daily missions.`;
     wrapper.appendChild(empty);
+    appendBounties();
     content.appendChild(wrapper);
     return;
   }
@@ -2592,6 +2641,7 @@ function renderMissionsView() {
     wrapper.appendChild(card);
   });
 
+  appendBounties();
   content.appendChild(wrapper);
 
   // Wire claim buttons
@@ -2615,6 +2665,19 @@ function renderMissionsView() {
         // Update credit badge
         const badge = document.getElementById('hangar-credits-amount');
         if (badge) badge.textContent = getLiveCredits().toLocaleString();
+      }
+
+      // Grant the mission's promised bonus tech fragment, if any — previously
+      // reward.techFragment was computed but never actually collected.
+      if (reward.techFragment && window.techFragmentSystem) {
+        const tfs = window.techFragmentSystem;
+        const fragment = tfs.rollDrop(true, false) || (window.TECH_FRAGMENTS || [])[0];
+        if (fragment) {
+          tfs.collect(fragment.id);
+          if (window.missionSystem) window.missionSystem.trackFragments(1);
+          const style = RARITY_STYLES[fragment.rarity] || {};
+          showAchievementToast({ icon: style.emoji || '💎', name: fragment.name, desc: 'Mission reward fragment collected!' });
+        }
       }
 
       // Re-render to show claimed state
@@ -3047,6 +3110,8 @@ function renderStatsView() {
     { label: 'DAILIES DONE',   value: achStats.dailyChallengesCompleted || 0,                 icon: '📅' },
     { label: 'UPGRADES MAXED', value: `${achStats.maxedHangarUpgrades || 0}`,                icon: '🔧' },
     { label: 'CREDITS BANKED', value: (saveData.credits || 0).toLocaleString(),               icon: '💰' },
+    { label: 'MISSIONS DONE',  value: window.missionSystem ? window.missionSystem.getTotalMissionsCompleted() : 0, icon: '📋' },
+    { label: 'BOUNTIES CLAIMED', value: window.missionSystem ? window.missionSystem.getTotalBountiesCompleted() : 0, icon: '⚠️' },
   ];
 
   const wrapper = document.createElement('div');

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -594,6 +594,23 @@ const HANGAR_UI_CSS = `
     text-shadow: 0 0 10px rgba(74, 222, 128, 0.5);
   }
 
+  .hangar-nav-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: #f97316;
+    color: #0b0f1a;
+    font-size: 10px;
+    font-weight: 900;
+    line-height: 16px;
+    text-align: center;
+    box-shadow: 0 0 6px rgba(249, 115, 22, 0.7);
+  }
+
   /* ── Achievement grid ──────────────────────────────────────── */
   .achievement-grid {
     display: grid;
@@ -2421,6 +2438,8 @@ function switchTab(tab) {
   } else {
     renderUpgradesView();
   }
+
+  updateMissionsNavBadge();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2473,6 +2492,40 @@ function handlePurchase(upgradeId) {
 // ─────────────────────────────────────────────────────────────────────────────
 // Missions tab
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Count completed-but-unclaimed daily missions, for the nav tab badge.
+ */
+function getUnclaimedMissionCount() {
+  const ms = window.missionSystem;
+  if (!ms || typeof ms.getDailyMissions !== 'function') return 0;
+  try {
+    return ms.getDailyMissions().filter(m => m.completed && !m.claimed).length;
+  } catch (e) {
+    return 0;
+  }
+}
+
+/**
+ * Show/hide a small count badge on the Missions nav tab when a reward is
+ * waiting to be claimed, so players don't have to open the tab to know.
+ */
+function updateMissionsNavBadge() {
+  const btn = document.querySelector('.hangar-tab-btn[data-tab="missions"]');
+  if (!btn) return;
+  const count = getUnclaimedMissionCount();
+  let badge = btn.querySelector('.hangar-nav-badge');
+  if (count > 0) {
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.className = 'hangar-nav-badge';
+      btn.appendChild(badge);
+    }
+    badge.textContent = String(count);
+  } else if (badge) {
+    badge.remove();
+  }
+}
 
 /**
  * Render the Missions tab — shows today's 3 daily missions with progress bars,
@@ -2593,6 +2646,7 @@ function renderMissionsView() {
 
       // Re-render to show claimed state
       renderMissionsView();
+      updateMissionsNavBadge();
     });
   });
 }
@@ -2999,6 +3053,7 @@ export function openHangar(opts = {}) {
 
   // Render real cards now that the overlay is in the DOM
   refreshGrid();
+  updateMissionsNavBadge();
 
   // ── Event listeners ──────────────────────────────────────────
 

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2025,6 +2025,8 @@ function renderSettingsView() {
   const sfxVal    = AM ? Math.round(AM.getVolume('sfx')    * 100) : 80;
   const musicVal  = AM ? Math.round(AM.getVolume('music')  * 100) : 50;
   const isMuted   = AM ? AM.getMuted() : false;
+  const shakeStored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+  const shakeVal  = Number.isFinite(shakeStored) ? shakeStored : 100;
 
   content.innerHTML = `
     <div class="hangar-settings">
@@ -2082,6 +2084,17 @@ function renderSettingsView() {
         <div class="hangar-daily-meta" id="hangar-daily-meta"></div>
         <button class="hangar-daily-btn" id="hangar-daily-start-btn">Start Today's Challenge</button>
       </div>
+      <div class="hangar-settings-section">
+        <div class="hangar-settings-label">🎬 Gameplay</div>
+
+        <div class="hangar-settings-row">
+          <span>Screen Shake</span>
+          <input type="range" class="hangar-settings-slider" id="settings-shake-intensity"
+                 min="0" max="150" value="${shakeVal}">
+          <span class="hangar-settings-vol" id="settings-shake-intensity-label">${shakeVal}%</span>
+        </div>
+      </div>
+
       <div class="hangar-settings-section hangar-theme-section">
         <div class="hangar-settings-label">🎨 HUD Theme</div>
         <div class="hangar-theme-swatches" id="hangar-theme-swatches">
@@ -2131,6 +2144,17 @@ function renderSettingsView() {
   wireSlider('settings-master-vol', 'settings-master-vol-label', 'master');
   wireSlider('settings-sfx-vol',    'settings-sfx-vol-label',    'sfx');
   wireSlider('settings-music-vol',  'settings-music-vol-label',  'music');
+
+  // Wire up screen shake intensity slider
+  const shakeSlider = document.getElementById('settings-shake-intensity');
+  const shakeLabel  = document.getElementById('settings-shake-intensity-label');
+  if (shakeSlider) {
+    shakeSlider.addEventListener('input', () => {
+      const val = parseInt(shakeSlider.value, 10);
+      if (shakeLabel) shakeLabel.textContent = `${val}%`;
+      localStorage.setItem('voidrift_screen_shake', String(val));
+    });
+  }
 
   // Wire up mute toggle
   const muteBtn = document.getElementById('settings-mute-btn');
@@ -2418,6 +2442,8 @@ function switchTab(tab) {
     renderStatsView();
   } else if (tab === 'missions') {
     renderMissionsView();
+  } else if (tab === 'loadout') {
+    renderLoadoutView();
   } else {
     renderUpgradesView();
   }
@@ -2624,6 +2650,151 @@ const RARITY_STYLES = {
     emoji: '⚡',
   },
 };
+
+/**
+ * Render the Loadout tab — configure the 4 equipment slots without needing
+ * to pause a run first. Reads/writes via _options.getLoadout/setLoadout so
+ * the change lands on the same save the in-game pause menu uses; falls back
+ * to a read-only notice if the caller didn't wire those callbacks.
+ */
+const LOADOUT_SLOT_OPTIONS = [
+  {
+    key: 'slot1', label: 'Slot 1 — Primary Weapon (always active)',
+    options: [
+      ['primary:pulse', 'Pulse Blaster'],
+      ['primary:scatter', 'Scatter Coil'],
+      ['primary:rail', 'Rail Lance'],
+      ['primary:ionburst', 'Ion Burst'],
+    ],
+  },
+  {
+    key: 'slot2', label: 'Slot 2 — Secondary Equipment',
+    options: [
+      ['defense:aegis', 'Aegis Shield'],
+      ['defense:reflector', 'Reflector Veil'],
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+      ['boost:boost', 'Boost'],
+    ],
+  },
+  {
+    key: 'slot3', label: 'Slot 3 — Secondary Equipment',
+    options: [
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+      ['defense:aegis', 'Aegis Shield'],
+      ['defense:reflector', 'Reflector Veil'],
+      ['boost:boost', 'Boost'],
+    ],
+  },
+  {
+    key: 'slot4', label: 'Slot 4 — Ultimate / Boost',
+    options: [
+      ['boost:boost', 'Boost'],
+      ['ultimate:voidstorm', 'Voidstorm'],
+      ['ultimate:solarbeam', 'Solar Beam'],
+      ['defense:aegis', 'Aegis Shield'],
+      ['secondary:nova', 'Nova Bomb'],
+      ['secondary:cluster', 'Cluster Barrage'],
+      ['secondary:seeker', 'Seeker Swarm'],
+      ['secondary:gravity', 'Gravity Well'],
+    ],
+  },
+];
+
+function renderLoadoutView() {
+  const content = document.getElementById('hangarContent');
+  if (!content) return;
+  content.innerHTML = '';
+
+  const equipClass = typeof _options.getLoadout === 'function' ? _options.getLoadout() : null;
+  const canEdit = !!equipClass && typeof _options.setLoadout === 'function';
+
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = 'padding:16px 16px 24px; overflow-y:auto; height:100%; box-sizing:border-box;';
+
+  const hdr = document.createElement('div');
+  hdr.style.cssText = [
+    'font-family:"Orbitron",monospace',
+    'font-size:11px',
+    'font-weight:700',
+    'letter-spacing:0.14em',
+    'color:rgba(255,255,255,0.3)',
+    'text-transform:uppercase',
+    'margin-bottom:14px',
+    'padding-bottom:10px',
+    'border-bottom:1px solid rgba(255,255,255,0.07)',
+  ].join(';');
+  hdr.textContent = 'EQUIPMENT LOADOUT';
+  wrapper.appendChild(hdr);
+
+  if (!canEdit) {
+    const notice = document.createElement('div');
+    notice.style.cssText = 'color:rgba(255,255,255,0.4); font-size:13px; padding:20px 0;';
+    notice.textContent = 'Loadout editing is unavailable right now — configure equipment from the in-game pause menu instead.';
+    wrapper.appendChild(notice);
+    content.appendChild(wrapper);
+    return;
+  }
+
+  const desc = document.createElement('p');
+  desc.style.cssText = 'color:rgba(255,255,255,0.45); font-size:12px; line-height:1.5; margin:0 0 18px;';
+  desc.textContent = 'Configure your 4 equipment slots before launch. Changes apply to your next run.';
+  wrapper.appendChild(desc);
+
+  const form = document.createElement('div');
+  form.style.cssText = 'display:flex; flex-direction:column; gap:14px;';
+
+  LOADOUT_SLOT_OPTIONS.forEach(({ key, label, options }) => {
+    const slotData = equipClass[key] || {};
+    const currentValue = `${slotData.type}:${slotData.id}`;
+
+    const row = document.createElement('label');
+    row.style.cssText = 'display:flex; flex-direction:column; gap:6px;';
+
+    const rowLabel = document.createElement('span');
+    rowLabel.style.cssText = 'font-size:12px; color:rgba(255,255,255,0.6); letter-spacing:0.02em;';
+    rowLabel.textContent = label;
+    row.appendChild(rowLabel);
+
+    const select = document.createElement('select');
+    select.className = 'hangar-loadout-select';
+    select.dataset.slot = key;
+    select.style.cssText = [
+      'background:rgba(255,255,255,0.05)',
+      'border:1px solid rgba(255,255,255,0.12)',
+      'border-radius:8px',
+      'color:#fff',
+      'padding:9px 12px',
+      'font-size:13px',
+      'font-family:inherit',
+    ].join(';');
+    options.forEach(([value, optLabel]) => {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = optLabel;
+      if (value === currentValue) opt.selected = true;
+      select.appendChild(opt);
+    });
+    row.appendChild(select);
+    form.appendChild(row);
+  });
+
+  wrapper.appendChild(form);
+  content.appendChild(wrapper);
+
+  form.addEventListener('change', (e) => {
+    const select = e.target.closest('.hangar-loadout-select');
+    if (!select) return;
+    const [type, id] = select.value.split(':');
+    const updated = { ...equipClass, [select.dataset.slot]: { type, id } };
+    _options.setLoadout(updated);
+  });
+}
 
 /**
  * Render the Fragments tab — shows all 6 tech fragments with collection status,
@@ -2977,6 +3148,7 @@ export function openHangar(opts = {}) {
         <button class="hangar-tab-btn" data-tab="skins">Skins</button>
         <button class="hangar-tab-btn" data-tab="armory">Armory</button>
         <button class="hangar-tab-btn" data-tab="missions">Missions</button>
+        <button class="hangar-tab-btn" data-tab="loadout">Loadout</button>
         <button class="hangar-tab-btn" data-tab="achievements">Achievements</button>
         <button class="hangar-tab-btn" data-tab="leaderboard">Leaderboard</button>
         <button class="hangar-tab-btn" data-tab="fragments">Fragments</button>

--- a/index.html
+++ b/index.html
@@ -774,6 +774,17 @@
           getSelectedShip: () => {
             return (window.Save && window.Save.data && window.Save.data.selectedShip) || 'vanguard';
           },
+          // Loadout tab reads/writes the same equipment class the in-game
+          // pause menu configures, so changes made here carry into the next run.
+          getLoadout: () => {
+            return (window.Save && window.Save.data && window.Save.data.armory && window.Save.data.armory.equipmentClass) || null;
+          },
+          setLoadout: (equipClass) => {
+            if (!window.Save || !window.Save.data) return;
+            if (!window.Save.data.armory) window.Save.data.armory = {};
+            window.Save.data.armory.equipmentClass = equipClass;
+            window.Save.save();
+          },
           // When a skin is equipped, re-init ship selection so colors update immediately
           onSkinEquip: (shipId, skinId, skin) => {
             if (window.__VOID_RIFT__ && typeof window.__VOID_RIFT__.initShipSelection === 'function') {

--- a/index.html
+++ b/index.html
@@ -745,6 +745,14 @@
   <!-- Persistent Upgrade Hangar (Base Mods) -->
   <script type="module">
     import { openHangar, closeHangar } from './hangar-ui.js';
+    import { loadHangar, applyHangarToConfig } from './src/systems/HangarSystem.js';
+
+    // Bridge HangarSystem's purchase-application helper to the classic-script
+    // game loop in script.js, which cannot use ES module imports directly.
+    // script.js calls this at the start of every run so purchased Base Mods
+    // upgrades (max HP, damage, speed, fire rate, credit bonus, piercing)
+    // actually affect gameplay instead of just being stored.
+    window.HangarSystem = { loadHangar, applyHangarToConfig };
 
     // Wire up the Base Mods nav button on the start screen.
     // We delay until DOMContentLoaded so the button element is guaranteed

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -722,7 +721,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
       "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -815,7 +813,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -839,7 +836,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2261,7 +2257,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2592,7 +2587,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3105,7 +3099,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4792,7 +4785,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",

--- a/script.js
+++ b/script.js
@@ -495,6 +495,14 @@
     { id: 'pierce', name: 'Armor Piercing', desc: 'Projectiles pass through additional enemies.', cat: 'Special', base: 200, step: 100, max: 3 }
   ];
 
+  // Named Bounty Targets (MissionSystem.js BOUNTY_TARGETS) each define a flavorful
+  // stats block (speed/health/damage/size) meant to make them feel mechanically
+  // distinct — e.g. "The Crimson Ace" fast and fragile vs "Iron Warlord" slow and
+  // tanky. These baselines are the average of those 5 stat blocks, so a bounty's
+  // own numbers are applied as a multiplier relative to a "typical" bounty rather
+  // than as absolute overrides that would ignore normal wave-based scaling.
+  const BOUNTY_STAT_BASELINE = { speed: 1.28, health: 520, damage: 26, size: 24.6 };
+
   // Adaptive difficulty - scales challenge based on player power
   // Adaptive difficulty constants
   const ADAPTIVE_CONSTANTS = {
@@ -6872,6 +6880,19 @@
               last.bountyName = namedBounty.name;
               last.bountyColor = namedBounty.color;
               window.missionSystem.markBountySpawned(namedBounty.id);
+              // Apply the named bounty's flavor stats (relative to the baseline
+              // across all bounties) so each one plays differently on top of
+              // the generic 2.5x/1.3x bounty scaling above.
+              if (namedBounty.stats) {
+                const s = namedBounty.stats;
+                if (s.speed)  last.speed *= s.speed / BOUNTY_STAT_BASELINE.speed;
+                if (s.damage) last.baseDamage *= s.damage / BOUNTY_STAT_BASELINE.damage;
+                if (s.size)   last.size *= s.size / BOUNTY_STAT_BASELINE.size;
+                if (s.health) {
+                  last.health = Math.ceil(last.health * (s.health / BOUNTY_STAT_BASELINE.health));
+                  last.maxHealth = last.health;
+                }
+              }
             }
           }
         }
@@ -7775,7 +7796,7 @@
       ctx.fill();
       
       // Main fuselage body - ENHANCED: wider and more substantial with intense glow
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2, size * 0.1);
       ctx.shadowColor = primary;
@@ -8028,7 +8049,7 @@
       ctx.stroke();
       
       // Main fuselage - long needle shape - ENHANCED: wider and more substantial
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2, size * 0.08);
       ctx.shadowColor = primary;
@@ -8225,7 +8246,7 @@
       }
       
       // Central main fuselage (armored box) - ENHANCED: wider and more armored looking
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2.5, size * 0.12);
       ctx.shadowColor = primary;
@@ -8462,7 +8483,7 @@
       ctx.stroke();
       
       // Angular main fuselage - ENHANCED: wider and more aggressive
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2, size * 0.09);
       ctx.shadowColor = primary;
@@ -8607,7 +8628,7 @@
       ctx.fill();
       
       // Central body spine - ENHANCED: wider and more substantial
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2, size * 0.08);
       ctx.shadowColor = primary;
@@ -8806,7 +8827,7 @@
       ctx.shadowBlur = 0;
       
       // Armored main hull - ENHANCED: wider and more tank-like
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2.5, size * 0.12);
       ctx.shadowColor = primary;
@@ -8925,7 +8946,7 @@
 
     } else {
       // Fallback to spear shape (default)
-      ctx.fillStyle = primary;
+      ctx.fillStyle = createMetallicGradient(ctx, -size, 0, size, 0, primary);
       ctx.strokeStyle = trim;
       ctx.lineWidth = Math.max(2, size * 0.1);
       ctx.beginPath();
@@ -9504,19 +9525,6 @@
     updateRadialMenuIcons();
   };
 
-  // Open the Hangar overlay wired to the live save, so its Loadout tab can
-  // read/write the same equipment class the in-game pause menu configures.
-  const openHangarOverlay = () => {
-    openHangar({
-      getLoadout: () => Save.data.armory.equipmentClass || defaultArmory().equipmentClass,
-      setLoadout: (equipClass) => {
-        Save.data.armory.equipmentClass = equipClass;
-        Save.save();
-        updateEquipmentIndicator();
-      }
-    });
-  };
-
   // Update radial menu icons to match equipment loadout
   const updateRadialMenuIcons = () => {
     const radialMenu = document.getElementById('radialMenu');
@@ -10027,6 +10035,32 @@
 
   const closeHangar = () => {
     dom.hangarModal.style.display = 'none';
+  };
+
+  // Open the full-featured Hangar overlay (Upgrades/Skins/Missions/Achievements/
+  // Leaderboard/Fragments/Stats/Settings) exposed by hangar-ui.js as window.openHangar.
+  // Named distinctly from the local openHangar() above (which only opens the
+  // simple ship-browser modal) so in-game entry points reach the real overlay
+  // instead of being silently shadowed by the local function of the same name.
+  const openPersistentHangar = () => {
+    if (typeof window.openHangar !== 'function') return;
+    window.openHangar({
+      getCredits: () => Save.data.credits,
+      spendCredits: (amount) => Save.spendCredits(amount),
+      getSelectedShip: () => Save.data.selectedShip || 'vanguard',
+      // Loadout tab reads/writes the same equipment class the in-game
+      // pause menu configures, so changes made here carry into the next run.
+      getLoadout: () => Save.data.armory.equipmentClass || defaultArmory().equipmentClass,
+      setLoadout: (equipClass) => {
+        Save.data.armory.equipmentClass = equipClass;
+        Save.save();
+        updateEquipmentIndicator();
+      },
+      onSkinEquip: () => {
+        initShipSelection();
+        if (player) player.reconfigureLoadout(true);
+      }
+    });
   };
   // ─── POWER-UP DROPS ─────────────────────────────────────────────────────────
   const PowerUps = (() => {
@@ -13336,6 +13370,9 @@
     openHangar,
     toggleFullscreen,
     toggleFPS,
+    // The Hangar overlay's onSkinEquip bridge (index.html) calls this after a
+    // skin is equipped so the ship preview picks up the new colors right away.
+    initShipSelection,
     getGameState: () => ({
       gameRunning,
       paused,
@@ -14251,7 +14288,7 @@
     });
     document.getElementById('pauseHangarBtn')?.addEventListener('click', () => {
       hidePauseMenu();
-      openHangarOverlay();
+      openPersistentHangar();
     });
     document.getElementById('pauseLeaderboardBtn')?.addEventListener('click', () => {
       hidePauseMenu();
@@ -14274,7 +14311,7 @@
       closeGameOverScreen();
       dom.gameContainer.style.display = 'none';
       dom.startScreen.style.display = 'flex';
-      openHangarOverlay();
+      openPersistentHangar();
     });
     document.getElementById('gameOverLeaderboardBtn')?.addEventListener('click', () => {
       closeGameOverScreen();
@@ -14350,7 +14387,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangarOverlay();
+      openPersistentHangar();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {
@@ -14508,7 +14545,7 @@
     
     document.getElementById('menuHangarBtn')?.addEventListener('click', () => {
       closeUnifiedMenu();
-      openHangarOverlay();
+      openPersistentHangar();
     });
     
     document.getElementById('menuLeaderboardBtn')?.addEventListener('click', () => {
@@ -14618,7 +14655,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangarOverlay();
+      openPersistentHangar();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {

--- a/script.js
+++ b/script.js
@@ -847,6 +847,9 @@
   let freezeExpiry = 0;          // timestamp when freeze effect ends
   let surgeDamageMultiplier = 1; // current damage multiplier (1 = no boost)
   let surgeExpiry = 0;           // timestamp when current boost ends
+  let timeWarpExpiry = 0;        // timestamp when Temporal Rift's enemy slow ends
+  let overchargeBoostMultiplier = 1; // current weapon damage multiplier from Overcharge Matrix
+  let overchargeBoostExpiry = 0;     // timestamp when the Overcharge boost ends
   let spawners = [];
   let starsFar = null;
   let starsMid = null;
@@ -1358,6 +1361,7 @@
   let comboTimer = 0;
   const COMBO_TIMEOUT = 2500; // ms - time between kills to maintain combo
   let totalKillsThisRun = 0;
+  let eliteKillsThisRun = 0;
 
   // Kill Combo Multiplier System
   let killComboMultiplier = 1;       // Current score multiplier (1–5)
@@ -2215,6 +2219,9 @@
     freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
+    timeWarpExpiry = 0;
+    overchargeBoostMultiplier = 1;
+    overchargeBoostExpiry = 0;
     spawners = [];
     particles = [];
     obstacles = [];
@@ -2283,6 +2290,7 @@
     comboCount = 0;
     comboTimer = 0;
     totalKillsThisRun = 0;
+    eliteKillsThisRun = 0;
     lastKillStreakNotification = 0;
     runShotsFired = 0;
     runShotsHit = 0;
@@ -7307,7 +7315,7 @@
         const speed = BASE.BULLET_SPEED * (weaponStats.bulletSpeed || 1) * perkMultipliers.bulletSpeed;
         const size = BASE.BULLET_SIZE * (weaponStats.bulletSize || 1);
         const pierce = (weaponStats.pierce || 0) + perkMultipliers.piercePlus;
-        const dmg = stats.dmg * perkMultipliers.damage * surgeDamageMultiplier;
+        const dmg = stats.dmg * perkMultipliers.damage * surgeDamageMultiplier * overchargeBoostMultiplier;
         bullets.push(new Bullet(sx, sy, vel, dmg, color, speed, size, pierce));
         runShotsFired++;
         waveShotsFired++;
@@ -7451,6 +7459,23 @@
         const length = stats.beamLength || 520;
         const width = stats.width || 90;
         applyBeamDamage(this.x, this.y, this.lookAngle, length, width, stats.damage || 220);
+      } else if (this.ultimate.id === 'timewarp') {
+        const slowFactor = stats.slowFactor ?? 0.3;
+        for (const e of enemies) {
+          if (e._preTimeWarpSpeed === undefined) e._preTimeWarpSpeed = e.speed;
+          e.speed = e._preTimeWarpSpeed * slowFactor;
+        }
+        timeWarpExpiry = now + (stats.duration || 5000);
+        addLogEntry('⏳ TEMPORAL RIFT! Enemies slowed', '#c084fc');
+      } else if (this.ultimate.id === 'supernova') {
+        applyRadialDamage(this.x, this.y, stats.radius || 400, stats.damage || 350, { pull: stats.pull || 0.6, knockback: 8, chargeMult: 0 });
+        const selfDamage = (stats.selfDamage || 0) * this.hpMax;
+        if (selfDamage > 0) {
+          this.health = clamp(this.health - selfDamage, 1, this.hpMax);
+          this.flash = true;
+          spawnDamageNumber(this.x, this.y - this.size, selfDamage, true);
+          addLogEntry(`☄️ Supernova overload! -${Math.round(selfDamage)} HP`, '#fb923c');
+        }
       } else {
         applyRadialDamage(this.x, this.y, stats.radius || 220, stats.damage || 160, { pull: stats.pull || 0.6, knockback: 8, chargeMult: 0 });
       }
@@ -7511,6 +7536,12 @@
         
         if ((this.defenseStats.reflect || 0) > 0 && mitigated > 0) {
           applyRadialDamage(this.x, this.y, this.size * 4, mitigated * (this.defenseStats.reflect || 0.25), { knockback: 2, chargeMult: 0.2 });
+        }
+        // Overcharge Matrix: converts absorbed damage into a temporary weapon power boost
+        if (this.defense?.id === 'overcharge' && mitigated > 0 && (this.defenseStats.damageBoost || 0) > 0) {
+          overchargeBoostMultiplier = 1 + this.defenseStats.damageBoost;
+          overchargeBoostExpiry = now + 3000;
+          addLogEntry('⚡ Overcharged! Weapon power boosted', '#eab308');
         }
       }
       if (amount <= 0) return;
@@ -9139,6 +9170,7 @@
 
     enemiesKilled++;
     waveKillCount++;
+    if (wasElite || enemy.type === 'elite') eliteKillsThisRun++;
     if (window.missionSystem) {
       const isBoss = !!enemy.isBoss;
       const isElite = !!(enemy.isElite || enemy.type === 'elite');
@@ -10357,6 +10389,22 @@
       freezeExpiry = 0;
       addLogEntry('Freeze ended', '#6b7280');
     }
+    // Expire Temporal Rift time-slow
+    if (timeWarpExpiry > 0 && now >= timeWarpExpiry) {
+      for (const e of enemies) {
+        if (e._preTimeWarpSpeed !== undefined) {
+          e.speed = e._preTimeWarpSpeed;
+          delete e._preTimeWarpSpeed;
+        }
+      }
+      timeWarpExpiry = 0;
+      addLogEntry('Temporal Rift ended', '#6b7280');
+    }
+    // Expire Overcharge Matrix weapon boost
+    if (overchargeBoostMultiplier > 1 && now > overchargeBoostExpiry) {
+      overchargeBoostMultiplier = 1;
+      addLogEntry('Overcharge faded', '#6b7280');
+    }
 
     for (const obstacle of obstacles) obstacle.update(dt);
 
@@ -10579,6 +10627,9 @@
     freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
+    timeWarpExpiry = 0;
+    overchargeBoostMultiplier = 1;
+    overchargeBoostExpiry = 0;
     spawners = [];
     particles = [];
     bossActive = false;
@@ -11111,6 +11162,22 @@
       ctx.fillStyle = '#e879f9';
       ctx.font = 'bold 10px Arial';
       ctx.fillText('⚡ SURGE', 16, canvas.height - 62);
+      ctx.restore();
+    }
+
+    // ── Overcharge Matrix HUD indicator ──────────────────────────────────────
+    if (overchargeBoostMultiplier > 1 && now < overchargeBoostExpiry) {
+      const remaining = (overchargeBoostExpiry - now) / 3000;
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      ctx.fillStyle = '#eab308';
+      ctx.fillRect(16, canvas.height - 76, 120 * remaining, 6);
+      ctx.strokeStyle = '#a16207';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(16, canvas.height - 76, 120, 6);
+      ctx.fillStyle = '#fde047';
+      ctx.font = 'bold 10px Arial';
+      ctx.fillText('⚡ OVERCHARGE', 16, canvas.height - 82);
       ctx.restore();
     }
 
@@ -12361,12 +12428,11 @@
     LocalLeaderboard.save(score);
     
     // Update game stats for achievements
-    // Note: Elite enemy tracking to be implemented in future update
     Auth.updateGameStats({
       kills: totalKillsThisRun,
       bossKills: bossActive ? 0 : (bossEntity ? 1 : 0),
       leviathanKills: leviathanKilledThisRun,
-      eliteKills: 0,
+      eliteKills: eliteKillsThisRun,
       playTime: performance.now() - (waveStartTime || performance.now()),
       flawlessLevel: !tookDamageThisLevel
     });

--- a/script.js
+++ b/script.js
@@ -887,6 +887,7 @@
   let pilotLevel = 1;
   let pilotXP = 0;
   let tookDamageThisLevel = false;
+  let lastCloseCallAt = 0;
   let gameOverHandled = false;
   let continueUsed = false;
   let runShotsFired = 0;
@@ -1354,6 +1355,45 @@
       setTimeout(() => el.remove(), 400);
     }, 2200);
   };
+  // Close Call bonus — brief flash when an enemy bullet grazes the player without hitting
+  const CLOSE_CALL_MARGIN = 16;    // px beyond the hit radius that counts as a graze
+  const CLOSE_CALL_COOLDOWN = 600; // ms between rewards, so a bullet stream can't spam it
+  const CLOSE_CALL_CREDITS = 2;
+  const CLOSE_CALL_SCORE = 15;
+
+  const showCloseCallFlash = () => {
+    const existing = document.getElementById('closeCallBanner');
+    if (existing) existing.remove();
+
+    const el = document.createElement('div');
+    el.id = 'closeCallBanner';
+    el.style.cssText = [
+      'position:fixed',
+      'top:16%',
+      'left:50%',
+      'transform:translate(-50%,-50%)',
+      'color:#38bdf8',
+      'font-size:15px',
+      'font-weight:700',
+      'letter-spacing:.08em',
+      'text-transform:uppercase',
+      'text-shadow:0 0 10px rgba(56,189,248,.8)',
+      'pointer-events:none',
+      'z-index:998',
+      'opacity:1',
+      'transition:opacity 0.5s, transform 0.5s',
+    ].join(';');
+    el.textContent = `⚡ CLOSE CALL! +${CLOSE_CALL_SCORE}`;
+    document.body.appendChild(el);
+
+    requestAnimationFrame(() => {
+      el.style.transform = 'translate(-50%,-70%)';
+    });
+    setTimeout(() => {
+      el.style.opacity = '0';
+      setTimeout(() => el.remove(), 500);
+    }, 500);
+  };
   // ── END PERK SYSTEM ───────────────────────────────────────────────────────
 
   // Phase 1: Combo & Kill Streak System
@@ -1361,6 +1401,7 @@
   let comboTimer = 0;
   const COMBO_TIMEOUT = 2500; // ms - time between kills to maintain combo
   let totalKillsThisRun = 0;
+  let peakComboThisRun = 0;
 
   // Kill Combo Multiplier System
   let killComboMultiplier = 1;       // Current score multiplier (1–5)
@@ -1640,6 +1681,9 @@
       this.save();
     }
   };
+  // Expose on window: the start-screen Hangar entry point (index.html) bridges
+  // credits/ship-selection/loadout callbacks through window.Save.
+  window.Save = Save;
 
   // Expose Save globally so hangar-ui.js can persist armory selections
   window.Save = Save;
@@ -2244,6 +2288,7 @@
     pilotLevel = Save.data.pilotLevel;
     pilotXP = Save.data.pilotXp;
     tookDamageThisLevel = false;
+    lastCloseCallAt = 0;
     gameOverHandled = false;
     continueUsed = false;
     if (window.missionSystem) { window.missionSystem.startRun(); updateMissionHUD(); }
@@ -2286,6 +2331,7 @@
     comboCount = 0;
     comboTimer = 0;
     totalKillsThisRun = 0;
+    peakComboThisRun = 0;
     lastKillStreakNotification = 0;
     runShotsFired = 0;
     runShotsHit = 0;
@@ -2384,9 +2430,16 @@
     }
   };
 
+  const getShakeIntensity = () => {
+    const stored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+    return (Number.isFinite(stored) ? stored : 100) / 100;
+  };
+
   const shakeScreen = (power = 4, duration = 120) => {
+    const scaledPower = power * getShakeIntensity();
+    if (scaledPower <= 0) return;
     shakeUntil = Math.max(shakeUntil, performance.now() + duration);
-    shakePower = power;
+    shakePower = scaledPower;
   };
 
   // ── Special Ability: fire the Q-key ability for the current ship ───────────
@@ -2492,6 +2545,7 @@
     comboCount++;
     comboTimer = now + COMBO_TIMEOUT;
     totalKillsThisRun++;
+    peakComboThisRun = Math.max(peakComboThisRun, comboCount);
     
     // Check for kill streak milestones
     for (const milestone of KILL_STREAK_MILESTONES) {
@@ -6505,8 +6559,9 @@
       const nx = movementX + ax;
       const ny = movementY + ay;
       const nm = Math.hypot(nx, ny) || 1;
-      this.x += (nx / nm) * this.speed * (dt / 16.67);
-      this.y += (ny / nm) * this.speed * (dt / 16.67);
+      const slowMoMult = PowerUps.enemySpeedMultiplier(Date.now());
+      this.x += (nx / nm) * this.speed * slowMoMult * (dt / 16.67);
+      this.y += (ny / nm) * this.speed * slowMoMult * (dt / 16.67);
       // Snipers lock rotation to aim angle during telegraph; otherwise face player
       if (this.kind === 'sniper' && (this.sniperPhase === 'aiming' || this.sniperPhase === 'cooldown')) {
         this.rot = this.sniperAimAngle;
@@ -9448,7 +9503,20 @@
     // Also update radial menu icons if it exists
     updateRadialMenuIcons();
   };
-  
+
+  // Open the Hangar overlay wired to the live save, so its Loadout tab can
+  // read/write the same equipment class the in-game pause menu configures.
+  const openHangarOverlay = () => {
+    openHangar({
+      getLoadout: () => Save.data.armory.equipmentClass || defaultArmory().equipmentClass,
+      setLoadout: (equipClass) => {
+        Save.data.armory.equipmentClass = equipClass;
+        Save.save();
+        updateEquipmentIndicator();
+      }
+    });
+  };
+
   // Update radial menu icons to match equipment loadout
   const updateRadialMenuIcons = () => {
     const radialMenu = document.getElementById('radialMenu');
@@ -9966,8 +10034,11 @@
       SHIELD: { color: '#22c55e', label: 'SHIELD +30', duration: 0, radius: 10 },
       RAPID:  { color: '#06b6d4', label: 'RAPID FIRE', duration: 8000, radius: 10 },
       NUKE:   { color: '#f97316', label: 'NUKE',       duration: 0, radius: 10 },
-      OVERDRIVE: { color: '#eab308', label: '2X SCORE', duration: 10000, radius: 10 },
+      OVERDRIVE: { color: '#a3e635', label: '2X SCORE', duration: 10000, radius: 10 },
+      MAGNET: { color: '#eab308', label: 'MAGNET',     duration: 10000, radius: 10 },
+      SLOWMO: { color: '#a855f7', label: 'SLOW-MO',    duration: 6000, radius: 10 },
     };
+    const SLOWMO_SPEED_MULT = 0.45;
     const TYPE_KEYS = Object.keys(TYPES);
     let active = [];       // live pickups on the ground
     let effects = [];      // active timed effects {type, endsAt}
@@ -10007,6 +10078,12 @@
       } else if (type === 'OVERDRIVE') {
         effects = effects.filter(e => e.type !== 'OVERDRIVE');
         effects.push({ type: 'OVERDRIVE', endsAt: now + 10000 });
+      } else if (type === 'MAGNET') {
+        effects = effects.filter(e => e.type !== 'MAGNET');
+        effects.push({ type: 'MAGNET', endsAt: now + TYPES.MAGNET.duration });
+      } else if (type === 'SLOWMO') {
+        effects = effects.filter(e => e.type !== 'SLOWMO');
+        effects.push({ type: 'SLOWMO', endsAt: now + TYPES.SLOWMO.duration });
       }
     }
 
@@ -10030,6 +10107,14 @@
 
     function isOverdriveActive(now) {
       return effects.some(e => e.type === 'OVERDRIVE' && e.endsAt > now);
+    }
+
+    function isMagnetActive(now) {
+      return effects.some(e => e.type === 'MAGNET' && e.endsAt > now);
+    }
+
+    function enemySpeedMultiplier(now) {
+      return effects.some(e => e.type === 'SLOWMO' && e.endsAt > now) ? SLOWMO_SPEED_MULT : 1;
     }
 
     function showPickupBanner(type) {
@@ -10067,29 +10152,28 @@
         ctx.fillText(p.type, p.x, p.y + 24);
         ctx.restore();
       });
-      // Rapid fire HUD indicator
-      const rapidEffect = effects.find(e => e.type === 'RAPID');
-      if (rapidEffect) {
-        const remaining = ((rapidEffect.endsAt - now) / 1000).toFixed(1);
+      // Timed-effect HUD indicators
+      const hudEffects = [
+        { type: 'RAPID',     icon: '⚡', color: '#06b6d4' },
+        { type: 'OVERDRIVE', icon: '★', color: '#a3e635' },
+        { type: 'MAGNET',    icon: '🧲', color: '#eab308' },
+        { type: 'SLOWMO',    icon: '🐢', color: '#a855f7' },
+      ];
+      let hudY = 110;
+      hudEffects.forEach(({ type, icon, color }) => {
+        const effect = effects.find(e => e.type === type);
+        if (!effect) return;
+        const remaining = ((effect.endsAt - now) / 1000).toFixed(1);
         ctx.save();
-        ctx.fillStyle = '#06b6d4'; ctx.font = 'bold 12px monospace';
+        ctx.fillStyle = color; ctx.font = 'bold 12px monospace';
         ctx.textAlign = 'left'; ctx.globalAlpha = 0.9;
-        ctx.fillText('⚡ RAPID ' + remaining + 's', 12, 110);
+        ctx.fillText(`${icon} ${TYPES[type].label} ${remaining}s`, 12, hudY);
         ctx.restore();
-      }
-      // Overdrive HUD indicator
-      const overdriveEffect = effects.find(e => e.type === 'OVERDRIVE');
-      if (overdriveEffect) {
-        const remaining = ((overdriveEffect.endsAt - now) / 1000).toFixed(1);
-        ctx.save();
-        ctx.fillStyle = '#eab308'; ctx.font = 'bold 12px monospace';
-        ctx.textAlign = 'left'; ctx.globalAlpha = 0.9;
-        ctx.fillText('★ 2X SCORE ' + remaining + 's', 12, rapidEffect ? 128 : 110);
-        ctx.restore();
-      }
+        hudY += 18;
+      });
     }
 
-    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive };
+    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive, isMagnetActive, enemySpeedMultiplier };
   })();
   // ─── END POWER-UP DROPS ─────────────────────────────────────────────────────
 
@@ -10220,7 +10304,8 @@
         coins.splice(i, 1);
         continue;
       }
-      const pickupRadius = player ? player.size + 80 : 120;
+      const magnetActive = PowerUps.isMagnetActive(now);
+      const pickupRadius = (player ? player.size + 80 : 120) * (magnetActive ? 6 : 1);
       const dx = player.x - coin.x;
       const dy = player.y - coin.y;
       const dist = Math.hypot(dx, dy);
@@ -10516,6 +10601,16 @@
         const adaptive = getAdaptiveScaling();
         const source = { shieldPenetration: adaptive.shieldPenetration * ADAPTIVE_CONSTANTS.BULLET_PENETRATION_FACTOR };
         player.takeDamage(bullet.damage, source);
+      } else if (
+        !bullet.nearMissCounted &&
+        dist < player.size + bullet.size + CLOSE_CALL_MARGIN &&
+        now - lastCloseCallAt > CLOSE_CALL_COOLDOWN
+      ) {
+        bullet.nearMissCounted = true;
+        lastCloseCallAt = now;
+        score += CLOSE_CALL_SCORE;
+        Save.addCredits(CLOSE_CALL_CREDITS);
+        showCloseCallFlash();
       }
     }
 
@@ -12516,7 +12611,18 @@
       playTime: performance.now() - (waveStartTime || performance.now()),
       flawlessLevel: !tookDamageThisLevel
     });
-    
+
+    // Feed the AchievementSystem lifetime totals so the Hangar's Achievements
+    // and Stats tabs (which read voidrift_achievements) actually update.
+    if (typeof window.updateAchievementStats === 'function') {
+      window.updateAchievementStats({
+        totalKills: Auth.playerProfile.totalKills,
+        maxWave: level,
+        bossKills: Auth.playerProfile.bossKills,
+        maxCombo: peakComboThisRun
+      });
+    }
+
     // Stop game and show game over screen
     gameRunning = false;
     paused = false;
@@ -12554,12 +12660,9 @@
         try {
           const completedCount = getTotalDailyChallengesCompleted();
           const streak = getDailyStreak();
-          import('./src/systems/AchievementSystem.js').then(({ updateStats }) => {
-            const newlyUnlocked = updateStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
-            if (newlyUnlocked && newlyUnlocked.length > 0 && typeof showAchievementToast === 'function') {
-              newlyUnlocked.forEach(ach => showAchievementToast(ach));
-            }
-          }).catch(err => console.warn('[DailyChallenge] Achievement update failed:', err));
+          if (typeof window.updateAchievementStats === 'function') {
+            window.updateAchievementStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
+          }
         } catch (e) {
           console.warn('[DailyChallenge] Achievement stats error:', e);
         }
@@ -14108,7 +14211,7 @@
     });
     document.getElementById('pauseHangarBtn')?.addEventListener('click', () => {
       hidePauseMenu();
-      openHangar();
+      openHangarOverlay();
     });
     document.getElementById('pauseLeaderboardBtn')?.addEventListener('click', () => {
       hidePauseMenu();
@@ -14131,7 +14234,7 @@
       closeGameOverScreen();
       dom.gameContainer.style.display = 'none';
       dom.startScreen.style.display = 'flex';
-      openHangar();
+      openHangarOverlay();
     });
     document.getElementById('gameOverLeaderboardBtn')?.addEventListener('click', () => {
       closeGameOverScreen();
@@ -14207,7 +14310,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangar();
+      openHangarOverlay();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {
@@ -14365,7 +14468,7 @@
     
     document.getElementById('menuHangarBtn')?.addEventListener('click', () => {
       closeUnifiedMenu();
-      openHangar();
+      openHangarOverlay();
     });
     
     document.getElementById('menuLeaderboardBtn')?.addEventListener('click', () => {
@@ -14475,7 +14578,7 @@
     });
     dom.openHangarFromShop?.addEventListener('click', () => {
       closeShop();
-      openHangar();
+      openHangarOverlay();
     });
     dom.hangarClose?.addEventListener('click', closeHangar);
     dom.hangarModal?.addEventListener('click', (e) => {

--- a/script.js
+++ b/script.js
@@ -1685,9 +1685,6 @@
   // credits/ship-selection/loadout callbacks through window.Save.
   window.Save = Save;
 
-  // Expose Save globally so hangar-ui.js can persist armory selections
-  window.Save = Save;
-
   const costOf = (upgrade) => {
     const lvl = Save.getUpgradeLevel(upgrade.id);
     return Math.floor(upgrade.base + upgrade.step * (lvl * 1.5 + lvl * lvl * 0.35));
@@ -2369,7 +2366,15 @@
       piercePlus:          0,
       fragmentOnImpact:    false
     };
-    
+
+    // Apply persistent Hangar (Base Mods) purchases — max HP, damage, speed,
+    // fire rate, credit bonus, and piercing tiers bought with credits between
+    // runs. Bridged via window.HangarSystem since this file is a classic
+    // script and HangarSystem.js is an ES module (see index.html).
+    if (window.HangarSystem && typeof window.HangarSystem.applyHangarToConfig === 'function') {
+      window.HangarSystem.applyHangarToConfig(window.HangarSystem.loadHangar(), perkMultipliers);
+    }
+
     Object.keys(input).forEach((k) => {
       if (typeof input[k] === 'boolean') input[k] = false;
       else input[k] = 0;
@@ -5073,14 +5078,15 @@
         ctx.stroke();
         ctx.restore();
       }
-      // Bounty target: gold crown above enemy
+      // Bounty target: crown above enemy, tinted with the named bounty's signature color
       if (this.isBounty) {
         ctx.save();
         const t = performance.now();
         const pulse = Math.sin(t / 300) * 0.15 + 0.85;
         ctx.globalAlpha = pulse;
-        ctx.fillStyle = '#fbbf24';
-        ctx.shadowColor = '#f59e0b';
+        const crownColor = this.bountyColor || '#fbbf24';
+        ctx.fillStyle = crownColor;
+        ctx.shadowColor = crownColor;
         ctx.shadowBlur = 16;
         // Crown base
         ctx.fillRect(-this.size * 0.6, -this.size * 1.9, this.size * 1.2, this.size * 0.3);
@@ -9029,8 +9035,8 @@
       } else {
         addLogEntry(`\u{1F4B0} BOUNTY CLAIMED! +${bountyReward} credits`, '#fbbf24');
       }
-      if (typeof AudioManager !== 'undefined' && AudioManager.playCoin) {
-        AudioManager.playCoin();
+      if (typeof AudioManager !== 'undefined' && AudioManager.playCoinPickup) {
+        AudioManager.playCoinPickup();
       }
     }
     if (wasBoss) {
@@ -9248,21 +9254,15 @@
     // Power-up drop chance on enemy death
     PowerUps.maybeSpawn(enemy.x, enemy.y);
 
-    // Tech fragment drop chance on elite/boss death
+    // Tech fragment drop chance on elite/boss death — spawns a real orbiting
+    // pickup in the world instead of auto-collecting; the player must fly
+    // over it (collection + notification handled in the main update loop).
     if (window.techFragmentSystem && (wasElite || wasBoss)) {
       const isBoss = !!wasBoss;
       const isElite = !!wasElite;
       const fragment = window.techFragmentSystem.rollDrop(isBoss, isElite);
       if (fragment) {
-        const pickup = window.techFragmentSystem.spawnPickup(fragment, enemy.x, enemy.y);
-        // Immediately collect the pickup and show notification (auto-collect on drop)
-        pickup.collected = true;
-        window.techFragmentSystem.collect(fragment.id);
-        if (window.missionSystem) window.missionSystem.trackFragments(1);
-        const count = window.techFragmentSystem.getFragmentCount(fragment.id);
-        if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
-          Auth.showTechFragmentNotification(count);
-        }
+        window.techFragmentSystem.spawnPickup(fragment, enemy.x, enemy.y);
       }
     }
 
@@ -10201,6 +10201,20 @@
     updateComboSystem(); // Phase 1: Update combo timer
     // Power-up pickup collection
     PowerUps.update(player.x, player.y, Date.now());
+    // Tech fragment pickup collection — orbiting drops from elite/boss kills
+    if (window.techFragmentSystem) {
+      const tfs = window.techFragmentSystem;
+      tfs.update(dt);
+      const collectedPickup = tfs.checkCollection(player.x, player.y, player.size);
+      if (collectedPickup) {
+        if (window.missionSystem) window.missionSystem.trackFragments(1);
+        if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
+        const count = tfs.getFragmentCount(collectedPickup.fragment.id);
+        if (typeof Auth !== 'undefined' && Auth.showTechFragmentNotification) {
+          Auth.showTechFragmentNotification(count);
+        }
+      }
+    }
     if (window.missionSystem && runStartTime > 0) {
       window.missionSystem.trackTime(Math.floor((now - runStartTime) / 1000));
     }
@@ -11256,6 +11270,31 @@
     drawParticles(ctx, 16.67);
     // Draw power-up orbs (in world space, before ctx.restore)
     PowerUps.draw(ctx);
+    // Draw orbiting tech fragment pickups
+    if (window.techFragmentSystem) {
+      for (const pickup of window.techFragmentSystem.active) {
+        const f = pickup.fragment;
+        const pulse = 0.75 + Math.sin(pickup.pulsePhase) * 0.25;
+        ctx.save();
+        ctx.translate(pickup.x, pickup.y);
+        ctx.rotate(pickup.angle);
+        ctx.globalAlpha = pulse;
+        ctx.shadowColor = f.glowColor || f.color;
+        ctx.shadowBlur = 18;
+        ctx.fillStyle = f.color;
+        ctx.beginPath();
+        ctx.moveTo(0, -pickup.size);
+        ctx.lineTo(pickup.size, 0);
+        ctx.lineTo(0, pickup.size);
+        ctx.lineTo(-pickup.size, 0);
+        ctx.closePath();
+        ctx.fill();
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 1.2;
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
     player.draw(ctx);
     // Draw Bulwark-7 shield wall arc
     drawShieldWall(ctx);
@@ -11521,8 +11560,9 @@
         ctx.save();
         ctx.globalAlpha = pulse;
         ctx.font = 'bold 13px Arial, sans-serif';
-        ctx.fillStyle = '#fbbf24';
-        ctx.shadowColor = '#f59e0b';
+        const bountyHudColor = aliveBounty.bountyColor || '#fbbf24';
+        ctx.fillStyle = bountyHudColor;
+        ctx.shadowColor = bountyHudColor;
         ctx.shadowBlur = 12;
         ctx.textAlign = 'right';
         ctx.textBaseline = 'top';


### PR DESCRIPTION
## Summary

Five small, self-contained improvements continuing the daily Void Rift improvement loop (following #125, #126, #129, #130). No persisted "5 tasks" list was found anywhere retrievable (checked scheduled cron jobs, repo files, and GitHub issues/PRs — consistent with every prior round), so a research agent surveyed the codebase for real gaps, cross-checked against `main` and all three still-open loop branches (`#125`, `#129`, `#130`) to avoid overlap.

- **fix: Elite kill tracking was hardcoded to 0** — `Auth.updateGameStats()` was called with `eliteKills: 0, // Note: Elite enemy tracking to be implemented in future update`, even though `enemy.isElite` is already tracked live for mission progress. This meant the "Elite Destroyer" achievement (kill 50 elite enemies) could never unlock, no matter how many elites a player killed. Added a real `eliteKillsThisRun` counter, incremented in `handleEnemyDeath`, and passed through at game-over.
- **feat: Temporal Rift ultimate now actually slows enemies** — its `slowFactor`/`duration` stats were fully defined in the `ARMORY` catalog but `fireUltimate()` only special-cased `solarbeam`; every other ultimate (including Temporal Rift) fell into the generic radial-damage branch, so it played identically to Voidstorm Cascade with none of its "slows time" identity. Now applies a per-enemy speed multiplier for the ultimate's duration, mirroring the existing Freeze Orb pickup's slow mechanic (with its own separate speed-backup field so the two don't clobber each other).
- **feat: Supernova Burst ultimate now applies its `selfDamage` stat** — the weapon's description ("channel all energy into a cataclysmic explosion") implies a real risk/reward tradeoff, but the self-damage was never actually dealt. Now costs the player HP proportional to `selfDamage × maxHP` (floored at 1 HP so it can't itself end the run), with a damage-number popup and log entry.
- **feat: Overcharge Matrix defense item's `damageBoost` stat is now applied** — described as "Converts incoming damage into temporary weapon power boost," but `takeDamage()`'s shield-absorb logic only ever read `absorb`/`reflect`; `damageBoost` was dead data, making it function as a strictly weaker Aegis Field. Now, absorbing damage while Overcharge is active grants a temporary weapon-damage multiplier, with a HUD timer bar matching the existing Power Surge indicator style.
- **feat: Missions nav tab shows an unclaimed-reward count badge** — the Missions tab already computed a completed-count internally, but nothing on the Hangar's tab bar signaled a reward was waiting, so players had to open the tab just to check. Adds a small orange count badge to the Missions nav button whenever there's a completed-but-unclaimed mission, updated on hangar open, tab switch, and claim.

## Test plan

- [x] `node --check` on both modified files
- [x] `npx jest` — 175/175 passing (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox)
- [x] `npx eslint script.js hangar-ui.js` — identical 39 problems (18 errors / 21 warnings) before and after this change; no new issues introduced
- [x] Playwright smoke test: opened the real Hangar overlay via `#openPermanentHangar` (the working entry point — the `window.openHangar` shadowing bug from #130 is still unfixed on `main`), forced a completed-but-unclaimed mission via `window.missionSystem`, and confirmed the nav badge renders "1" after a tab switch, and disappears once claimed
- [x] Playwright smoke test: started a live run via `window.__VOID_RIFT__.startGame()`, ran 4s at 58fps with zero new console/page errors (confirmed identical pre-existing 2 page errors on both the base commit and this branch, unrelated to this diff)
- [ ] Manual playtest of the Temporal Rift slow, Supernova self-damage, and Overcharge Matrix boost in a live run — these require charging an ultimate / tanking shielded damage, which isn't reachable through the exposed `window.__VOID_RIFT__` debug hooks without adding new instrumentation; verified via code review + automated checks only (recommend a quick playthrough before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g5D2FRtUQLh9vvC3ZzyrR

---
_Generated by [Claude Code](https://claude.ai/code/session_011g5D2FRtUQLh9vvC3ZzyrR)_