### PR TITLE
Daily improvement loop: leaderboard-system.js syntax fix, local leaderboard key fix, daily challenge best-display fix, Critical Strike + Reactive Armor upgrade wiring

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2344,7 +2344,7 @@ function _buildLeaderboardTable(container, entries, emptyMsg = 'No runs recorded
     const diff = entry.difficulty ? entry.difficulty.charAt(0).toUpperCase() + entry.difficulty.slice(1) : '—';
     const date = entry.timestamp
       ? new Date(entry.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-      : '—';
+      : (entry.date || '—'); // local entries store a pre-formatted date string, not a timestamp
     const pilot = entry.username || entry.userId || 'Pilot';
     const tr = document.createElement('tr');
     tr.className = `hangar-lb-row ${rowClass}`;
@@ -2394,12 +2394,16 @@ function renderLeaderboardView() {
   if (_lbMode === 'local') {
     let entries = [];
     try {
-      const raw = localStorage.getItem('void_rift_leaderboard');
+      // Read from the same key script.js's LocalLeaderboard actually writes to
+      // (voidrift_local_scores) — this used to read 'void_rift_leaderboard',
+      // a key nothing ever populates, so the tab was always empty. Local
+      // entries are stored as {score, date} with no username field.
+      const raw = localStorage.getItem('voidrift_local_scores');
       if (raw) {
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed)) {
           entries = parsed
-            .filter(e => e && typeof e.score === 'number' && typeof e.username === 'string')
+            .filter(e => e && typeof e.score === 'number')
             .sort((a, b) => b.score - a.score)
             .slice(0, 20);
         }

--- a/leaderboard-system.js
+++ b/leaderboard-system.js
@@ -141,7 +141,7 @@ const LeaderboardSystem = {
         
         const headers = { 'Content-Type': 'application/json' };
         if (token) {
-          headers.Authorization = `******;
+          headers.Authorization = `Bearer ${token}`;
         }
         
         const response = await fetch(LEADERBOARD_CONFIG.API_URL, {
@@ -225,121 +225,7 @@ const LeaderboardSystem = {
     throw lastError;
   }
 };
-    return localScores
-      .filter(entry => entry.userId === user.id)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, 10);
-  },
-  
-  /**
-   * Get user's rank for a specific score
-   * @param {number} score
-   * @param {string} difficulty
-   * @returns {Promise<number>} User's rank (1-based)
-   */
-  async getUserRank(score, difficulty = 'all') {
-    const scores = await this.fetchScores(difficulty, 1000);
-    const higherScores = scores.filter(entry => entry.score > score);
-    return higherScores.length + 1;
-  },
-  
-  /**
-   * Clear local leaderboard data
-   */
-  clearLocal() {
-    try {
-      localStorage.removeItem(LEADERBOARD_CONFIG.LOCAL_KEY);
-    } catch (error) {
-      console.error('Failed to clear local leaderboard:', error);
-    }
-  },
-  
-  /**
-   * Submit score to backend
-   * @private
-   */
-  async _submitToBackend(entry, token) {
-    for (let attempt = 0; attempt < LEADERBOARD_CONFIG.RETRY_ATTEMPTS; attempt++) {
-      try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), LEADERBOARD_CONFIG.TIMEOUT_MS);
-        
-        const headers = { 'Content-Type': 'application/json' };
-        if (token) {
-          headers.Authorization = `Bearer ${token}`;
-        }
-        
-        const response = await fetch(LEADERBOARD_CONFIG.API_URL, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            ...entry,
-            authToken: token
-          }),
-          signal: controller.signal
-        });
-        
-        clearTimeout(timeout);
-        
-        const data = await response.json();
-        
-        if (!response.ok) {
-          throw new Error(data.error || `HTTP ${response.status}`);
-        }
-        
-        return {
-          success: true,
-          rank: data.rank,
-          storage: data.storage || 'kv'
-        };
-      } catch (error) {
-        if (attempt < LEADERBOARD_CONFIG.RETRY_ATTEMPTS - 1) {
-          await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-        } else {
-          throw error;
-        }
-      }
-    }
-  },
-  
-  /**
-   * Fetch scores from backend
-   * @private
-   */
-  async _fetchFromBackend(difficulty, limit) {
-    for (let attempt = 0; attempt < LEADERBOARD_CONFIG.RETRY_ATTEMPTS; attempt++) {
-      try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), LEADERBOARD_CONFIG.TIMEOUT_MS);
-        
-        const url = new URL(LEADERBOARD_CONFIG.API_URL);
-        url.searchParams.set('difficulty', difficulty);
-        url.searchParams.set('limit', Math.min(limit, 100));
-        
-        const response = await fetch(url, {
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
-          signal: controller.signal
-        });
-        
-        clearTimeout(timeout);
-        
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        
-        const data = await response.json();
-        return data.entries || [];
-      } catch (error) {
-        if (attempt < LEADERBOARD_CONFIG.RETRY_ATTEMPTS - 1) {
-          await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-        } else {
-          throw error;
-        }
-      }
-    }
-  },
-  
+
 // Make available globally
 if (typeof window !== 'undefined') {
   window.LeaderboardSystem = LeaderboardSystem;

--- a/script.js
+++ b/script.js
@@ -12907,11 +12907,15 @@
 
     // Save daily challenge best and restore Math.random
     if (window.DAILY_CHALLENGE_ACTIVE) {
-      import('./daily-challenge.js').then(({ saveDailyBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted }) => {
+      import('./daily-challenge.js').then(({ saveDailyBest, getTodayBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted }) => {
+        // saveDailyBest() only overwrites the stored best when finalScore is
+        // actually higher — but its return value was previously discarded,
+        // so the display below unconditionally showed *this run's* score
+        // even after a worse run, overwriting a legitimately higher best.
         saveDailyBest(finalScore);
         deactivateDailyChallenge();
         const bestEl = document.getElementById('dailyBestDisplay');
-        if (bestEl) bestEl.textContent = `Best: ${finalScore.toLocaleString()}`;
+        if (bestEl) bestEl.textContent = `Best: ${getTodayBest().toLocaleString()}`;
 
         // Update achievement stats for daily challenge completion
         try {

--- a/script.js
+++ b/script.js
@@ -10345,9 +10345,18 @@
         const dx = bullet.x - enemy.x;
         const dy = bullet.y - enemy.y;
         if (Math.hypot(dx, dy) < bullet.size + enemy.size) {
-          // AI Targeting Matrix tech fragment: chance to crit for bonus damage
           let hitDamage = bullet.damage;
           let isCrit = false;
+          // Critical Strike shop upgrade ('crit'): was purchasable with credits
+          // (see UPGRADES catalog) but its level was never read anywhere —
+          // players could max it out for zero effect. 5% chance per level,
+          // double damage, up to 30% at max level 6.
+          const shopCritChance = Save.getUpgradeLevel('crit') * 0.05;
+          if (shopCritChance > 0 && Math.random() < shopCritChance) {
+            hitDamage *= 2;
+            isCrit = true;
+          }
+          // AI Targeting Matrix tech fragment: chance to crit for bonus damage
           if (window.techFragmentSystem && window.techFragmentSystem.hasFragment('neural_chip') && window.TECH_UNLOCKS) {
             const critStats = window.TECH_UNLOCKS.ai_targeting.stats;
             if (Math.random() < critStats.critChance) {

--- a/script.js
+++ b/script.js
@@ -7647,6 +7647,11 @@
       if (amount <= 0) return;
       // Reinforced Hull perk: reduce damage taken
       amount *= perkMultipliers.damageTakenMult;
+      // Reactive Armor shop upgrade ('armor'): purchasable ("Reduce incoming
+      // damage percentage") but its level was never applied anywhere — fixed
+      // to actually mitigate damage. 5% per level, capped at 25% at max level 5.
+      const armorLevel = Save.getUpgradeLevel('armor');
+      if (armorLevel > 0) amount *= (1 - Math.min(0.5, armorLevel * 0.05));
       if (amount <= 0) return;
       tookDamageThisLevel = true;
       if (window.missionSystem) window.missionSystem.trackDamage(amount);

--- a/script.js
+++ b/script.js
@@ -8,7 +8,6 @@
   /* ====== CONFIG ====== */
   const SAVE_KEY = 'void_rift_v11';
   const AUTH_KEY = 'void_rift_auth';
-  const LEADERBOARD_KEY = 'void_rift_leaderboard';
 
   const DIFFICULTY_PRESETS = {
     easy: {


### PR DESCRIPTION
## Summary

Fifth round of the daily improvement loop. Surveyed `script.js`, `hangar-ui.js`, `leaderboard-system.js`, and `daily-challenge.js` for real, self-contained gaps — dead code, unwired catalog data, and discarded return values — and fixed 5 of them. Deliberately avoided the areas claimed by the still-open, unmerged **#132** (Tech Fragment persistence, Void Phantom `phase_blink`, Iron Warlord `tank_barrage`, Seeker Swarm homing drones, mission `xpBoost`, `setupInput()` duplicate listeners) — none of this round's fixes touch that surface.

- **`leaderboard-system.js` had a genuine, committed syntax error — the global leaderboard silently never worked.** An unterminated template literal on the `Authorization` header line (`` headers.Authorization = `******; ``) swallowed everything up to the next backtick, and a duplicated/orphaned copy of `getUserRank`/`clearLocal`/`_submitToBackend`/`_fetchFromBackend` sat outside the object literal entirely. Confirmed with `node --check` / eslint ("Unexpected token HTTP") and independently in a real Chromium load: `window.LeaderboardSystem` was `undefined` before the fix. Since this is loaded as a classic `<script>`, the parse failure silently broke every consumer — `script.js` score submission/fetch, the Hangar's Global leaderboard tab, and `social-ui.js`'s leaderboard modal. Fixed the template literal and removed the dead duplicate block, keeping the one complete implementation.
- **Hangar's "Local" Leaderboard tab always showed "No runs recorded yet."** It read `localStorage['void_rift_leaderboard']` and required a `username` field on each entry. Nothing ever wrote to that key — the actual local top-5 leaderboard (`script.js`'s `LocalLeaderboard`, populated on every game over) is stored under `voidrift_local_scores` as `{score, date}` entries with no username at all. Pointed the tab at the real key, dropped the bogus filter (pilot name already falls back to "Pilot"), and let the date column use the entry's pre-formatted date string when there's no numeric timestamp. Also removed the dead `LEADERBOARD_KEY` constant in `script.js` that was the likely source of the wrong-key copy/paste (defined, never read — already flagged by eslint).
- **Daily Challenge "Best" display could show a worse score as the best.** `saveDailyBest(finalScore)` only updates the stored best when the new score is actually higher, but its boolean return value was discarded — the UI label was unconditionally set to the *current run's* score. A run that scored below a previous personal best would overwrite the on-screen "Best: ..." with the worse number (the underlying stored value was never corrupted, just the label). Now reads back `getTodayBest()` after saving.
- **Critical Strike shop upgrade did nothing.** The `crit` upgrade ("Chance for double damage on hits") was purchasable with credits and its level persisted, but no code ever read `Save.getUpgradeLevel('crit')` — only the unrelated `neural_chip` tech fragment's crit chance was ever rolled. Added an independent roll in the bullet-hit path: 5% chance per level, double damage, up to 30% at max level 6.
- **Reactive Armor shop upgrade did nothing.** Same bug, different stat: `armor` ("Reduce incoming damage percentage") was purchasable but never applied in `Player#takeDamage`. Now mitigates 5% damage per level, capped at 25% at max level 5, applied alongside the existing Reinforced Hull perk multiplier.

Two other dead shop-upgrade ids (`luck`, `ultimate`, `cooldown`, `pierce`) were also found unwired during the survey but left for a future round to keep this diff focused.

## Test plan

- [x] `node --check` on all modified files (`script.js`, `hangar-ui.js`, `leaderboard-system.js`) — all pass
- [x] `npx jest` — 175/175 passing (the pre-existing `leaderboard-api.test.js` failure is unrelated, needs `@vercel/kv`, same as every prior round)
- [x] `npx eslint script.js hangar-ui.js` — 39 problems vs. 40 on the base commit (net improvement from removing the dead `LEADERBOARD_KEY` constant; no new problems introduced)
- [x] Browser smoke test via Playwright (available in this sandbox): loaded `index.html`, confirmed `window.LeaderboardSystem` / `submitScore` now exist (were `undefined` before the fix), called `window.__VOID_RIFT__.startGame()`, opened the Hangar and clicked into the Leaderboard tab — no new console/page errors introduced. One pre-existing, unrelated page error (`Unexpected token '.'`) is present on both the base commit and this branch; not touched by this PR.

Note: **#132** is still open and unmerged — this round was scoped to avoid any overlap with its listed items.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8PK3dwjKRnnWgswpqsQwp)_