### PR TITLE
Daily improvement loop: mission credit fix, Herald of Void wave-priority bug, 4 dead shop upgrades, 3 bounty behaviors

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2704,21 +2704,17 @@ function renderMissionsView() {
       const reward = ms.claimMissionReward(missionId);
       if (!reward) return;
 
-      // Grant credits to the main save if the callback is available
-      if (typeof _options.getCredits === 'function' && typeof _options.spendCredits !== 'function') {
-        // Read-only accessor provided — can't grant; store for next session via HangarSystem pool
-      }
-      // Attempt to add credits via the external handler or internal pool
+      // Attempt to add credits via the external handler (bridges into the main
+      // game's Save balance) or fall back to the hangar's own internal pool.
       if (typeof _options.addCredits === 'function') {
         _options.addCredits(reward.credits);
       } else {
-        // Fallback: credit the internal hangar pool
         _hangarState.credits = (_hangarState.credits || 0) + reward.credits;
         saveHangar(_hangarState);
-        // Update credit badge
-        const badge = document.getElementById('hangar-credits-amount');
-        if (badge) badge.textContent = getLiveCredits().toLocaleString();
       }
+      // Update credit badge — needed for both paths above
+      const badge = document.getElementById('hangar-credits-amount');
+      if (badge) badge.textContent = getLiveCredits().toLocaleString();
 
       // Grant the mission's promised bonus tech fragment, if any — previously
       // reward.techFragment was computed but never actually collected.

--- a/index.html
+++ b/index.html
@@ -780,6 +780,13 @@
             }
             return false; // fall back — internal pool handles it
           },
+          // Grants (e.g. mission reward claims) go to the main Save balance
+          // when available, instead of the hangar's disconnected internal pool.
+          addCredits: (amount) => {
+            if (window.Save && typeof window.Save.addCredits === 'function') {
+              window.Save.addCredits(amount);
+            }
+          },
           // Provide the currently selected ship so the Skins tab defaults to it
           getSelectedShip: () => {
             return (window.Save && window.Save.data && window.Save.data.selectedShip) || 'vanguard';

--- a/script.js
+++ b/script.js
@@ -6671,6 +6671,64 @@
         }
       }
 
+      // Named Bounty Target unique behaviors — layered on top of the generic
+      // kind-based movement above. (phase_blink/tank_barrage are handled at
+      // their own dedicated sites elsewhere.)
+      if (this.bountyBehavior === 'aggressive_dodge') {
+        // Crimson Ace: charges the player harder, and juts perpendicular
+        // when a player bullet is on a near-collision course.
+        movementX *= 1.35;
+        movementY *= 1.35;
+        for (const b of bullets) {
+          if (b.isEnemy) continue;
+          const bdx = this.x - b.x;
+          const bdy = this.y - b.y;
+          const bdist = Math.hypot(bdx, bdy);
+          if (bdist > 140) continue;
+          const bvel = Math.hypot(b.vel.x, b.vel.y) || 1;
+          const toward = (bdx * b.vel.x + bdy * b.vel.y) / (bdist * bvel);
+          if (toward > 0.5) {
+            movementX += (-b.vel.y / bvel) * 1.6;
+            movementY += (b.vel.x / bvel) * 1.6;
+          }
+        }
+      } else if (this.bountyBehavior === 'time_distortion') {
+        // Quantum Hunter: speeds itself up and applies a one-time slow to
+        // player bullets as they enter its aura.
+        movementX *= 1.5;
+        movementY *= 1.5;
+        for (const b of bullets) {
+          if (b.isEnemy || b.timeDistorted) continue;
+          if (Math.hypot(b.x - this.x, b.y - this.y) < 220) {
+            b.speed *= 0.6;
+            b.timeDistorted = true;
+          }
+        }
+      } else if (this.bountyBehavior === 'spawn_minions') {
+        // Swarm Queen: periodically calls in small swarmer reinforcements,
+        // capped so it can't flood the wave indefinitely.
+        const bnow = performance.now();
+        if (!this.minionSpawnTimer) this.minionSpawnTimer = bnow;
+        if (bnow - this.minionSpawnTimer > 4000) {
+          this.minionSpawnTimer = bnow;
+          const nearbyMinions = enemies.filter(e =>
+            e !== this && e.kind === 'swarmer' && Math.hypot(e.x - this.x, e.y - this.y) < 400
+          ).length;
+          if (nearbyMinions < 4) {
+            for (let m = 0; m < 2; m++) {
+              const spawnAngle = Math.random() * Math.PI * 2;
+              const spawnDist = this.size + 30;
+              enemies.push(new Enemy(
+                this.x + Math.cos(spawnAngle) * spawnDist,
+                this.y + Math.sin(spawnAngle) * spawnDist,
+                'swarmer', false, false
+              ));
+            }
+            addLogEntry('🐝 Swarm Queen summoned reinforcements!', '#ec4899');
+          }
+        }
+      }
+
       const nx = movementX + ax;
       const ny = movementY + ay;
       const nm = Math.hypot(nx, ny) || 1;
@@ -6980,6 +7038,11 @@
               last.bountyId = namedBounty.id;
               last.bountyName = namedBounty.name;
               last.bountyColor = namedBounty.color;
+              // Each named bounty declares a distinct AI `behavior` flavor
+              // string (see BOUNTY_TARGETS in MissionSystem.js) — dispatched
+              // in Enemy.update() below so bounties don't all just play like
+              // reskinned stat blocks of their base kind.
+              last.bountyBehavior = namedBounty.behavior || null;
               window.missionSystem.markBountySpawned(namedBounty.id);
               // Apply the named bounty's flavor stats (relative to the baseline
               // across all bounties) so each one plays differently on top of
@@ -7121,7 +7184,10 @@
       const defenseStats = (this.defense && this.defense.stats) || {};
       const ultimateStats = (this.ultimate && this.ultimate.stats) || {};
       this.secondaryCapacity = Math.max(0, Math.round(secondaryStats.ammo || 0));
-      this.secondaryCooldownMs = secondaryStats.cooldown || 9000;
+      // System Coolant shop upgrade ('cooldown'): was purchasable but its level
+      // was never read anywhere — 5% shorter cooldowns per level, up to 25% at max level 5.
+      const cooldownMult = 1 - Math.min(0.5, Save.getUpgradeLevel('cooldown') * 0.05);
+      this.secondaryCooldownMs = (secondaryStats.cooldown || 9000) * cooldownMult;
       this.secondaryAmmo = preserveVitals ? clamp(Math.round(this.secondaryCapacity * prevSecondaryRatio), 0, this.secondaryCapacity) : this.secondaryCapacity;
       this.defenseStats = defenseStats;
       if (!preserveVitals) {
@@ -7492,7 +7558,9 @@
         const sy = this.y + Math.sin(angle) * this.size * 0.9;
         const speed = BASE.BULLET_SPEED * (weaponStats.bulletSpeed || 1) * perkMultipliers.bulletSpeed;
         const size = BASE.BULLET_SIZE * (weaponStats.bulletSize || 1);
-        const pierce = (weaponStats.pierce || 0) + perkMultipliers.piercePlus;
+        // Armor Piercing shop upgrade ('pierce'): was purchasable but its level
+        // was never read anywhere — +1 pierce per level, up to +3 at max level 3.
+        const pierce = (weaponStats.pierce || 0) + perkMultipliers.piercePlus + Save.getUpgradeLevel('pierce');
         const dmg = stats.dmg * perkMultipliers.damage * surgeDamageMultiplier * overchargeBoostMultiplier;
         bullets.push(new Bullet(sx, sy, vel, dmg, color, speed, size, pierce));
         runShotsFired++;
@@ -7601,7 +7669,10 @@
       if (!this.defense) return false;
       const stats = this.defense.stats || {};
       if (now < this.defenseReadyAt) return false;
-      this.defenseReadyAt = now + (stats.cooldown || 12000);
+      // System Coolant shop upgrade ('cooldown') also reduces the defense
+      // system's recharge time, matching the secondary-weapon cooldown above.
+      const cooldownMult = 1 - Math.min(0.5, Save.getUpgradeLevel('cooldown') * 0.05);
+      this.defenseReadyAt = now + (stats.cooldown || 12000) * cooldownMult;
       this.defenseActiveUntil = now + (stats.duration || 3000);
       addParticles('shield', this.x, this.y, 0, 24);
       shakeScreen(4, 140);
@@ -7664,7 +7735,10 @@
       if (!amount || amount <= 0) return;
       const fragmentRate = (window.techFragmentSystem && window.techFragmentSystem.hasFragment('antimatter_vial'))
         ? (window.TECH_UNLOCKS.antimatter_reactor.stats.ultimateChargeRate || 1) : 1;
-      this.ultimateCharge = clamp(this.ultimateCharge + amount * fragmentRate, 0, this.ultimateChargeMax);
+      // Ultimate Charger shop upgrade ('ultimate'): was purchasable but its level
+      // was never read anywhere — 5% faster charge per level, up to 25% at max level 5.
+      const upgradeRate = 1 + Save.getUpgradeLevel('ultimate') * 0.05;
+      this.ultimateCharge = clamp(this.ultimateCharge + amount * fragmentRate * upgradeRate, 0, this.ultimateChargeMax);
     }
 
     collectSupply(kind) {
@@ -10177,6 +10251,9 @@
     window.openHangar({
       getCredits: () => Save.data.credits,
       spendCredits: (amount) => Save.spendCredits(amount),
+      // Mission-reward credit claims must land in the real Save balance,
+      // not the hangar's own disconnected internal credit pool.
+      addCredits: (amount) => Save.addCredits(amount),
       getSelectedShip: () => Save.data.selectedShip || 'vanguard',
       // Loadout tab reads/writes the same equipment class the in-game
       // pause menu configures, so changes made here carry into the next run.
@@ -10494,7 +10571,10 @@
       if (dist < player.size + coin.r) {
         coins.splice(i, 1);
         score += 10;
-        const coinCredits = killComboMultiplier > 1 ? killComboMultiplier : 1;
+        const rawCoinCredits = killComboMultiplier > 1 ? killComboMultiplier : 1;
+        // Fortune Module shop upgrade ('luck'): was purchasable but its level
+        // was never read anywhere — 5% more credits per level, up to 30% at max level 6.
+        const coinCredits = Math.round(rawCoinCredits * (1 + Save.getUpgradeLevel('luck') * 0.05));
         Save.addCredits(coinCredits);
         if (window.missionSystem) window.missionSystem.trackCredits(coinCredits);
         addXP(6);
@@ -10821,7 +10901,9 @@
   const advanceLevel = () => {
     // Reset per-wave stats before accumulating this wave's rewards
     waveCreditsEarned = 0;
-    const _creditsBase = Math.floor(20 + level * 5 + enemiesKilled * 1.5);
+    // Fortune Module shop upgrade ('luck') applies to this per-kill wave-clear
+    // reward too, same as the coin-pickup credits above.
+    const _creditsBase = Math.floor((20 + level * 5 + enemiesKilled * 1.5) * (1 + Save.getUpgradeLevel('luck') * 0.05));
     Save.addCredits(_creditsBase);
     waveCreditsEarned += _creditsBase;
     addXP(90 + level * 12);
@@ -10879,18 +10961,23 @@
       leviathanWavePending = true;
       voidSurgeWavePending = false;
       addLogEntry(`☠️ LEVIATHAN APPROACHES — FLEE OR FIGHT!`, '#FF2020');
-    } else if (bossLevel) {
-      currentWaveType = 'boss';
-      leviathanWavePending = false;
-      voidSurgeWavePending = false;
-      addLogEntry(`⚠️ BOSS WAVE INCOMING!`, '#dc2626');
     } else if (voidSurgeLevel) {
-      // VOID SURGE — elite wave with dramatic overlay + HERALD OF VOID boss
+      // VOID SURGE — elite wave with dramatic overlay + HERALD OF VOID boss.
+      // Checked before the generic bossLevel below: whenever the current
+      // adaptive bossInterval (3-7) happens to divide evenly into a void
+      // surge level (15, 40, 65, 90, ...), bossLevel is ALSO true — if that
+      // branch ran first it would silently swallow this one, spawning a
+      // plain boss wave and skipping the HERALD OF VOID encounter entirely.
       currentWaveType = 'elite';
       voidSurgeWavePending = true;
       voidSurgeBossPending = true;
       leviathanWavePending = false;
       addLogEntry(`⚡ VOID SURGE INCOMING — HERALD OF VOID APPROACHES!`, '#8b5cf6');
+    } else if (bossLevel) {
+      currentWaveType = 'boss';
+      leviathanWavePending = false;
+      voidSurgeWavePending = false;
+      addLogEntry(`⚠️ BOSS WAVE INCOMING!`, '#dc2626');
     } else if (level % 5 === 0 && getPowerRatio() > 0.3) {
       // Every 5th level (non-boss), special wave type
       const waveTypes = ['swarm', 'elite', 'survival', 'hazard'];


### PR DESCRIPTION
## Summary

Sixth round of the daily improvement loop. Surveyed `script.js`, `hangar-ui.js`, and `index.html` for real, self-contained gaps not already covered by the still-open, unmerged **#132** (Tech Fragment persistence, Void Phantom `phase_blink`, Iron Warlord `tank_barrage`, Seeker Swarm homing drones, mission `xpBoost`, `setupInput()` duplicate listeners) and **#133** (leaderboard-system.js syntax error, local leaderboard key, daily challenge best-display, Critical Strike + Reactive Armor upgrade wiring).

- **fix: mission-tab credit rewards were silently discarded.** Claiming a mission's credit reward in `hangar-ui.js` only ever fell into the internal `_hangarState.credits` pool fallback, because neither `openHangar()` call site (`script.js`'s `openPersistentHangar`, `index.html`'s start-screen wiring) passed an `addCredits` callback. That pool is disconnected from the real balance the player actually spends (`Save.data.credits`/`getLiveCredits()`), so claimed credits vanished without even updating the badge. Wired `addCredits` at both call sites to `Save.addCredits`, and fixed the claim handler to refresh the credit badge on both the callback and fallback path.
- **fix: HERALD OF VOID boss wave could be silently skipped.** Wave-type selection checked the generic `bossLevel` (`level % adaptive.bossInterval`) before `voidSurgeLevel` (15, 40, 65, 90, ...). Since `bossInterval` ranges 3-7, whenever it evenly divided a void-surge level the generic boss branch won and the entire HERALD OF VOID encounter never spawned — a plain boss appeared instead with no indication anything was skipped. Reordered so `voidSurgeLevel` is checked first.
- **feat: wired 4 of the 15 persistent shop upgrades** that were purchasable with real credits but had zero gameplay effect (their level was never read anywhere) — Fortune Module (`luck`, +5%/level credits from enemies, applied to coin pickups and wave-clear rewards), Ultimate Charger (`ultimate`, +5%/level ultimate charge rate), System Coolant (`cooldown`, -5%/level secondary weapon and defense system cooldowns), and Armor Piercing (`pierce`, +1 pierce per level).
- **feat: named Bounty Targets' `behavior` field is dead flavor data** — wired the 3 behaviors not already claimed by #132: Crimson Ace (`aggressive_dodge` — charges harder, sidesteps incoming player bullets), Swarm Queen (`spawn_minions` — periodically calls in swarmer reinforcements, capped), and Quantum Hunter (`time_distortion` — speeds itself up, applies a one-time slow to player bullets entering its aura).

## Test plan

- [x] `node --check` on all modified files
- [x] `npx jest` — 175/175 passing (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox — same as noted in #132/#133)
- [x] `npx eslint script.js hangar-ui.js` — identical 40 problems (17 errors / 23 warnings) before and after this change; no new issues introduced
- [x] Playwright smoke test: served over `python3 -m http.server`, loaded `index.html`, started a live run via `window.__VOID_RIFT__.startGame()`, ran 5s — identical console/page error set before and after this branch's changes (all pre-existing: network-blocked external resources, and the leaderboard-system.js syntax error #133 already fixes)
- [x] Standalone logic check confirming the reordered wave-priority branch picks `void-surge` over `boss` at every conflicting (level, bossInterval) combination (15/40/65/90 × bossInterval 3-7)
- [ ] Manual playtest of the Fortune Module/Ultimate Charger/System Coolant/Armor Piercing upgrades and the 3 bounty behaviors — these require specific in-run conditions (purchased upgrades, a spawned named bounty) not reachable through the exposed debug hooks without new instrumentation; verified via code review + automated checks only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U1FssagqZ4NUbksFNRsWEA)_