### PR TITLE
Daily improvement loop: auth-system.js syntax fix, prestige wiring, Void Shield/Clone Bay upgrades, achievement categories, leaderboard best

### DIFF
--- a/auth-system.js
+++ b/auth-system.js
@@ -323,55 +323,7 @@ const AuthSystem = {
       return { success: false, error: error.message };
     }
   },
-          this.notifyAuthChange();
-          
-          return {
-            success: true,
-            xpGain: response.xpGain || 0,
-            levelUp: response.profile.level > oldLevel
-          };
-        }
-        
-        return { success: false, error: response.error };
-      }
-      
-      // Update local stats
-      if (!this.session.user.profile) this.session.user.profile = {};
-      if (!this.session.user.stats) this.session.user.stats = {};
-      
-      const profile = this.session.user.profile;
-      const stats = this.session.user.stats;
-      
-      // Update profile stats
-      profile.gamesPlayed = (profile.gamesPlayed || 0) + 1;
-      profile.totalScore = (profile.totalScore || 0) + (gameData.score || 0);
-      profile.highScore = Math.max(profile.highScore || 0, gameData.score || 0);
-      
-      // Update detailed stats
-      stats.kills = (stats.kills || 0) + (gameData.kills || 0);
-      stats.deaths = (stats.deaths || 0) + (gameData.deaths || 0);
-      stats.playTime = (stats.playTime || 0) + (gameData.duration || 0);
-      
-      // Calculate XP gain
-      const xpGain = Math.floor((gameData.score || 0) / 10);
-      profile.xp = (profile.xp || 0) + xpGain;
-      const oldLevel = profile.level || 1;
-      profile.level = Math.floor(profile.xp / 100) + 1;
-      
-      this.saveSession();
-      this.notifyAuthChange();
-      
-      return {
-        success: true,
-        xpGain,
-        levelUp: profile.level > oldLevel
-      };
-    } catch (error) {
-      console.error('Stats update error:', error);
-      return { success: false, error: error.message };
-    }
-  },
-  
+
   /**
    * Register callback for auth state changes
    * @param {Function} callback - Function to call when auth state changes

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -3208,6 +3208,45 @@ function renderStatsView() {
   });
 
   wrapper.appendChild(grid);
+
+  // ── Prestige ─────────────────────────────────────────────────────────────
+  // Auth.doPrestige() resets Pilot Level to 1 in exchange for a permanent
+  // title (and, at select tiers, a rare weapon or ship unlock). It had no
+  // caller anywhere in the UI, so it — and the prestige_1/5/10 achievements
+  // that key off it — could never be reached through normal play.
+  const auth = window.Auth;
+  if (auth && typeof auth.canPrestige === 'function') {
+    const profile = auth.playerProfile || {};
+    const prestigeBox = document.createElement('div');
+    prestigeBox.style.cssText = 'margin-top:16px; background:rgba(192,132,252,0.06); border:1px solid rgba(192,132,252,0.25); border-radius:10px; padding:14px 16px;';
+
+    if (auth.canPrestige()) {
+      prestigeBox.innerHTML = `
+        <div style="font-size:11px;color:#c084fc;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:8px;">&#11088; Prestige Available</div>
+        <div style="font-size:12px;color:rgba(255,255,255,0.6);margin-bottom:10px;">Reset your Pilot Level to 1 for a permanent title and reward. Credits and upgrades are kept.</div>
+        <button id="hangar-prestige-btn" style="padding:8px 16px; border-radius:8px; border:1px solid rgba(192,132,252,0.4); background:rgba(192,132,252,0.15); color:#e9d5ff; font-weight:700; cursor:pointer;">Prestige Now (${(profile.prestige || 0) + 1}/10)</button>
+      `;
+    } else {
+      const current = profile.prestige || 0;
+      prestigeBox.innerHTML = `
+        <div style="font-size:11px;color:rgba(255,255,255,0.3);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px;">&#11088; Prestige ${current}/10${profile.title ? ` — ${profile.title}` : ''}</div>
+        <div style="font-size:11px;color:rgba(255,255,255,0.28);">Reach Pilot Level 50 to prestige again.</div>
+      `;
+    }
+    wrapper.appendChild(prestigeBox);
+
+    const prestigeBtn = prestigeBox.querySelector('#hangar-prestige-btn');
+    if (prestigeBtn) {
+      prestigeBtn.addEventListener('click', () => {
+        if (window.confirm('Prestige now? Your Pilot Level will reset to 1. Credits and upgrades are kept.')) {
+          if (auth.doPrestige()) {
+            renderStatsView();
+          }
+        }
+      });
+    }
+  }
+
   content.appendChild(wrapper);
 }
 

--- a/script.js
+++ b/script.js
@@ -1779,8 +1779,8 @@
     { id: 'upgrader', name: 'Upgrader', desc: 'Purchase 10 upgrades', icon: 'assets/icons/achievement-upgrade.svg', category: 'special', requirement: { totalUpgrades: 10 } }
   ];
 
-  // Achievement categories for UI grouping (used by profile renderer)
-  // eslint-disable-next-line no-unused-vars
+  // Achievement categories — labels the category badge shown on the
+  // unlock toast (see showAchievementNotification below).
   const ACHIEVEMENT_CATEGORIES = {
     combat: { name: 'Combat', icon: 'assets/icons/achievement-sword.svg' },
     survival: { name: 'Survival', icon: 'assets/icons/achievement-shield.svg' },
@@ -2028,6 +2028,7 @@
       const stackOffset = existing.length * 90;
 
       // Create achievement toast notification
+      const category = ACHIEVEMENT_CATEGORIES[achievement.category];
       const toast = document.createElement('div');
       toast.className = 'achievement-toast';
       toast.style.top = `${20 + stackOffset}px`;
@@ -2037,7 +2038,7 @@
                onerror="this.style.display='none';this.parentElement.textContent='🏆'" />
         </div>
         <div class="achievement-toast-content">
-          <div class="achievement-toast-title">Achievement Unlocked!</div>
+          <div class="achievement-toast-title">Achievement Unlocked!${category ? ` <span class="achievement-toast-category">${category.name}</span>` : ''}</div>
           <div class="achievement-toast-name">${achievement.name}</div>
           <div class="achievement-toast-desc">${achievement.desc}</div>
         </div>
@@ -2112,6 +2113,11 @@
       this.checkAchievements();
     }
   };
+  // Expose on window: hangar-ui.js is an ES module and cannot see this
+  // script's closure directly. Without this, canPrestige()/doPrestige()
+  // (and the prestige_1/5/10 achievements they gate) are unreachable from
+  // any UI — there is no other bridge into the Prestige system.
+  window.Auth = Auth;
 
   /* ====== LOCAL LEADERBOARD (localStorage top-5) ====== */
   const LOCAL_SCORES_KEY = 'voidrift_local_scores';
@@ -2219,11 +2225,14 @@
       return [];
     },
     
-    getUserBest(username) {
+    async getUserBest(username) {
       // Use new LeaderboardSystem
       if (this.useGlobal && typeof LeaderboardSystem !== 'undefined') {
         try {
-          const userScores = LeaderboardSystem.getUserBestScores();
+          // getUserBestScores() is async — it must be awaited, otherwise
+          // `userScores` is a pending Promise and `.length` is always
+          // undefined, so this silently returned null for every caller.
+          const userScores = await LeaderboardSystem.getUserBestScores();
           return userScores.length > 0 ? userScores[0] : null;
         } catch (err) {
           return null;
@@ -7116,6 +7125,11 @@
       } else {
         this.health = this.hpMax;
         this.ammo = this.ammoMax;
+        // Hangar "Void Shield" / "Emergency Clone Bay" upgrades only apply at
+        // the start of a fresh run (preserveVitals === false) — otherwise
+        // they'd silently refill on every wave transition.
+        this.shieldHp = Math.max(0, perkMultipliers.startShield || 0);
+        this.livesRemaining = Math.max(0, Math.round(perkMultipliers.extraLives || 0));
       }
       const secondaryStats = (this.secondary && this.secondary.stats) || {};
       const defenseStats = (this.defense && this.defense.stats) || {};
@@ -7726,6 +7740,14 @@
       // Reinforced Hull perk: reduce damage taken
       amount *= perkMultipliers.damageTakenMult;
       if (amount <= 0) return;
+      // Hangar "Void Shield" upgrade: absorb damage from a separate pool
+      // before any of it reaches HP.
+      if (this.shieldHp > 0) {
+        const absorbed = Math.min(this.shieldHp, amount);
+        this.shieldHp -= absorbed;
+        amount -= absorbed;
+        if (amount <= 0) return;
+      }
       tookDamageThisLevel = true;
       if (window.missionSystem) window.missionSystem.trackDamage(amount);
       this.health -= amount;
@@ -7753,8 +7775,16 @@
       }
       
       if (this.health <= 0) {
-        this.health = 0;
-        gameRunning = false;
+        // Hangar "Emergency Clone Bay" upgrade: revive instead of ending the run.
+        if (this.livesRemaining > 0) {
+          this.livesRemaining--;
+          this.health = Math.ceil(this.hpMax * 0.5);
+          this.invEnd = now + BASE.INVULN_MS * 3;
+          addLogEntry('💚 Emergency Clone Bay activated! Extra life used', '#4ade80');
+        } else {
+          this.health = 0;
+          gameRunning = false;
+        }
       }
     }
   }
@@ -13517,17 +13547,32 @@
     
     const entries = await Leaderboard.getEntries(difficulty, 100);
     const currentUsername = Auth.getCurrentUsername();
-    
+
     if (entries.length === 0) {
       dom.leaderboardList.innerHTML = '<div class="leaderboard-empty">No scores yet. Be the first!</div>';
       return;
     }
-    
-    const sourceLabel = Leaderboard.useGlobal 
-      ? '<div style="text-align:center;color:#22c55e;font-size:12px;margin-bottom:8px;">🌍 Global Leaderboard - Top 100</div>' 
+
+    const sourceLabel = Leaderboard.useGlobal
+      ? '<div style="text-align:center;color:#22c55e;font-size:12px;margin-bottom:8px;">🌍 Global Leaderboard - Top 100</div>'
       : '<div style="text-align:center;color:#eab308;font-size:12px;margin-bottom:8px;">📱 Local Scores - Top 100</div>';
-    
-    dom.leaderboardList.innerHTML = sourceLabel + entries.map((entry, index) => {
+
+    // "Your Best" banner — surfaces Leaderboard.getUserBest(), which previously
+    // returned null unconditionally due to a missing await on the underlying
+    // async call, so it had never been worth wiring into the UI before.
+    let personalBestLabel = '';
+    if (Leaderboard.useGlobal && currentUsername) {
+      try {
+        const best = await Leaderboard.getUserBest(currentUsername);
+        if (best) {
+          personalBestLabel = `<div style="text-align:center;color:#93c5fd;font-size:11px;margin-bottom:8px;">⭐ Your Best: ${best.score.toLocaleString()} (Lvl ${best.level})</div>`;
+        }
+      } catch (err) {
+        // Non-fatal — leaderboard still renders without the personal-best banner.
+      }
+    }
+
+    dom.leaderboardList.innerHTML = sourceLabel + personalBestLabel + entries.map((entry, index) => {
       const rank = index + 1;
       const isCurrentUser = currentUsername && entry.username.toLowerCase() === currentUsername.toLowerCase();
       const rankClass = rank === 1 ? 'top-1' : rank === 2 ? 'top-2' : rank === 3 ? 'top-3' : '';

--- a/style.css
+++ b/style.css
@@ -4431,6 +4431,20 @@ html, body {
   letter-spacing: 0.5px;
 }
 
+.achievement-toast-category {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(74, 222, 128, 0.12);
+  color: rgba(74, 222, 128, 0.85);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 .achievement-toast-name {
   font-size: 15px;
   color: #e2e8f0;


### PR DESCRIPTION
## Summary

This continues the recurring daily improvement loop (previously merged: #125, #126, #129, #130, #131). There are currently three other open rounds in flight — **#132**, **#133**, **#134** — this PR is scoped to avoid any overlap with them:

- #132 covers mission `xpBoost` wiring, tech fragment save persistence, homing Bullet/Seeker Swarm, Gravity Well sustained pull, Void Phantom/Iron Warlord bounty behaviors, and duplicate shop/hangar close listeners.
- #133 covers the `leaderboard-system.js` corrupted-template-literal syntax error + dead code, the local-leaderboard localStorage key mismatch, the daily-challenge best-score display, and the `armor`/`crit` shop upgrades.
- #134 covers the mission credit callback, the Herald of Void wave-priority bug, the `cooldown`/`pierce`/`ultimate`/`luck` shop upgrades, and 3 more bounty behaviors.

This round surveyed the rest of the codebase (script.js, hangar-ui.js, index.html, auth-system.js, style.css, and the `src/systems/*` modules) for 5 new, non-overlapping, self-contained gaps.

## Changes

- **fix: `auth-system.js` fatal syntax error.** `AuthSystem.updateStats()` had a duplicate, unreachable tail of an older implementation left dangling directly inside the object literal, right after the method's real closing brace — a bare `this.notifyAuthChange();` sitting outside any function. That's a hard `SyntaxError: Unexpected token '.'`, which means the *entire file* fails to parse in the browser, so `window.AuthSystem` is never defined. Every `typeof AuthSystem !== 'undefined'` guard throughout `script.js`/`social-ui.js` then silently takes the "no backend" branch — breaking real login, registration, and stat sync outright. Removed the orphaned dead code so the file parses and the real backend-only `updateStats()` implementation is reachable again.

- **feat: wire the Prestige system into the Hangar.** `Auth.canPrestige()` / `Auth.doPrestige()` (grants a permanent title plus, at select tiers, a rare weapon or ship unlock — and gates the `prestige_1`/`prestige_5`/`prestige_10` achievements) had no caller anywhere in the UI. Worse, there was no way to add one: `Auth` was never exposed on `window`, so `hangar-ui.js` (an ES module with no access to `script.js`'s closure) had no bridge into it at all. Exposed `window.Auth` and added a Prestige card to the Hangar's Stats tab showing current prestige/title, with a button to trigger it once Pilot Level 50 is reached.

- **fix: wire the "Void Shield" and "Emergency Clone Bay" Hangar upgrades.** Both are real, purchasable, credit-costed upgrades in `HangarSystem.js` — `apply()` mutates `perkMultipliers.startShield` / `perkMultipliers.extraLives` on purchase — but nothing in the game ever read either field, so buying them was a pure credit sink with zero gameplay effect. The player now gets a `shieldHp` absorption pool at the start of each run (drained before HP on hits) and a `livesRemaining` counter (revives at 50% HP instead of ending the run) sized from those purchased tiers.

- **fix: `Leaderboard.getUserBest()` missing `await`.** It called the async `LeaderboardSystem.getUserBestScores()` without awaiting it, so `userScores` was a pending Promise and `userScores.length` was always `undefined` — the method silently returned `null` for every caller, always. Added the `await` and wired a "Your Best" banner into the global leaderboard modal so the fix is actually visible.

- **feat: wire `ACHIEVEMENT_CATEGORIES` into the achievement-unlock toast.** This category map (Combat/Survival/Score/Pilot/Prestige/Special) was defined with an `eslint-disable-next-line no-unused-vars` and a comment claiming it was "used by profile renderer" — no such renderer exists anywhere in the codebase, so it was fully dead. The unlock toast now shows a small category badge next to "Achievement Unlocked!".

## Test plan

- [x] `node --check` on all modified `.js` files (`script.js`, `hangar-ui.js`, `auth-system.js`)
- [x] `npx jest`: 175/175 passing (the `leaderboard-api.test.js` suite still fails on missing `@vercel/kv`, pre-existing and unrelated to this change)
- [x] `npx eslint script.js`: 39 problems before and after this change — no new errors/warnings introduced
- [x] `npx eslint auth-system.js`: previously 1 fatal parse error (the syntax bug this PR fixes); now parses cleanly with only pre-existing `no-console`/`no-undef(module)` style warnings
- [x] `npx eslint hangar-ui.js`: same pre-existing `sourceType: module` parser-config warning before and after (the project's `.eslintrc.json` only fully configures `script.js`, per `package.json`'s `lint` script)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPztKBYfqJwaQedDUYPSbC)_