### PR TITLE
Daily improvement loop: mission fragment gap, boss-enrage reset, orb/buff state leaking across runs

### DIFF
--- a/script.js
+++ b/script.js
@@ -2271,12 +2271,16 @@
     medicOrbs = [];
     ghostOrbs = [];
     freezeOrbs = [];
+    lightningOrbs = [];
+    lightningArcs = [];
+    lightningFlashEnd = 0;
     freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     timeWarpExpiry = 0;
     overchargeBoostMultiplier = 1;
     overchargeBoostExpiry = 0;
+    PowerUps.reset();
     spawners = [];
     particles = [];
     obstacles = [];
@@ -10282,6 +10286,11 @@
       return effects.some(e => e.type === 'SLOWMO' && e.endsAt > now) ? SLOWMO_SPEED_MULT : 1;
     }
 
+    function reset() {
+      active = [];
+      effects = [];
+    }
+
     function showPickupBanner(type) {
       const cfg = TYPES[type];
       const el = document.createElement('div');
@@ -10338,7 +10347,7 @@
       });
     }
 
-    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive, isMagnetActive, enemySpeedMultiplier };
+    return { maybeSpawn, update, draw, isRapidActive, isOverdriveActive, isMagnetActive, enemySpeedMultiplier, reset };
   })();
   // ─── END POWER-UP DROPS ─────────────────────────────────────────────────────
 
@@ -10602,7 +10611,7 @@
       const dx = player.x - orb.x;
       const dy = player.y - orb.y;
       const dist = Math.hypot(dx, dy);
-      if (dist > 220) {
+      if (dist < 220) {
         orb.x += (dx / (dist || 1)) * 1.1;
         orb.y += (dy / (dist || 1)) * 1.1;
       }
@@ -10939,12 +10948,16 @@
     medicOrbs = [];
     ghostOrbs = [];
     freezeOrbs = [];
+    lightningOrbs = [];
+    lightningArcs = [];
+    lightningFlashEnd = 0;
     freezeExpiry = 0;
     surgeDamageMultiplier = 1;
     surgeExpiry = 0;
     timeWarpExpiry = 0;
     overchargeBoostMultiplier = 1;
     overchargeBoostExpiry = 0;
+    PowerUps.reset();
     spawners = [];
     particles = [];
     bossActive = false;

--- a/script.js
+++ b/script.js
@@ -2341,6 +2341,7 @@
     bountySpawnedThisWave = false;
     bountyKilledTotal = 0;
     bossWaveAnnouncementStart = 0;
+    bossEnrageAnnouncementStart = 0;
     if (dom.bossBar) dom.bossBar.style.display = 'none';
 
     // Phase 1: Reset combo and kill streak

--- a/src/systems/MissionSystem.js
+++ b/src/systems/MissionSystem.js
@@ -38,7 +38,11 @@ const MISSION_TEMPLATES = [
   // Credits missions
   { type: MISSION_TYPES.COLLECT_CREDITS, target: 200, reward: 100, xpBoost: 1.1, name: 'Scavenger', desc: 'Collect {target} credits' },
   { type: MISSION_TYPES.COLLECT_CREDITS, target: 500, reward: 250, xpBoost: 1.2, name: 'Prospector', desc: 'Collect {target} credits' },
-  
+
+  // Tech fragment missions
+  { type: MISSION_TYPES.COLLECT_FRAGMENTS, target: 2, reward: 200, xpBoost: 1.2, name: 'Fragment Hunter', desc: 'Collect {target} tech fragments' },
+  { type: MISSION_TYPES.COLLECT_FRAGMENTS, target: 4, reward: 400, xpBoost: 1.35, name: 'Relic Seeker', desc: 'Collect {target} tech fragments' },
+
   // Boss/Elite missions
   { type: MISSION_TYPES.KILL_BOSSES, target: 3, reward: 300, techFragment: true, name: 'Boss Hunter', desc: 'Defeat {target} boss enemies' },
   { type: MISSION_TYPES.KILL_ELITES, target: 10, reward: 200, xpBoost: 1.3, name: 'Elite Destroyer', desc: 'Defeat {target} elite enemies' },


### PR DESCRIPTION
## Summary

Four small, self-contained improvements continuing the daily Void Rift improvement loop (following #125, #126, #129, #130, #131, and alongside the still-open #132, #133, #134, #135). As with every prior round, no persisted "5 tasks" list was found anywhere retrievable (checked cron jobs, repo files, and GitHub issues/PRs), so this round was selected by surveying the codebase for real gaps — cross-checked line-by-line against the diffs and current file state of all four still-open loop branches to avoid overlap. Two additional candidates (Gravity Well's dead `pull` stat, Seeker Swarm's dead `seekers` stat) were investigated and dropped once direct inspection of #132's branch showed it already implements both.

Only 4 verified gaps made the cut this round rather than the usual 5 — two other leads (a duplicate-key bug in `firebase-backend.js` and a stale `audio-manager.js` assumption) were investigated and rejected as either unreachable dead code or not actually broken, and I'd rather ship 4 verified fixes than pad to 5 with something shaky.

- **fix: `COLLECT_FRAGMENTS` mission type could never be generated.** `MissionSystem.js`'s `trackFragments()` already calls `updateMissionProgress(MISSION_TYPES.COLLECT_FRAGMENTS, ...)` on every fragment pickup, but no `MISSION_TEMPLATES` entry ever used that type — so fragment collection could never appear as, or complete, a daily mission despite being fully tracked. Added two templates ("Fragment Hunter" / "Relic Seeker"). Confirmed end-to-end with a Playwright smoke test: `collect_fragments` now shows up in `window.missionSystem.dailyMissions`.
- **fix: "BOSS ENRAGED!" screen flash could bleed into the next run.** The run-reset block resets `bossWaveAnnouncementStart` but was missing its sibling `bossEnrageAnnouncementStart` — since both are raw `performance.now()` timestamps that don't reset on their own, dying/restarting within ~2.2s of a boss enraging could flash the red "BOSS ENRAGED! ATTACK PATTERN CHANGING" overlay for a moment at the start of the next run.
- **fix: Freeze Orb's magnet was inverted.** Every sibling orb (Power Surge, Medic, Ghost, Lightning) drifts toward the player once they get *close* (`dist < X`). Freeze Orb alone used `dist > 220` — it only drifted while far away and went completely inert the moment the player got within range, so it had to be flown into directly instead of magnetizing like every other orb. One-character fix (`>` → `<`).
- **fix: orb/timed-buff state wasn't cleared between runs or waves.** `lightningOrbs`/`lightningArcs`/`lightningFlashEnd` were missing from both the run-restart and wave-transition reset blocks (their four sibling arrays — `powerSurges`/`medicOrbs`/`ghostOrbs`/`freezeOrbs` — are correctly cleared in both places). More impactful: the older `PowerUps` module's `active` ground pickups and, worse, its `effects` array (RAPID/OVERDRIVE/MAGNET/SLOWMO timed buffs) were *never* reset anywhere, unlike every other timed-buff system in the file (Power Surge, Overcharge Matrix, Temporal Rift all reset on both restart and wave transition). Concretely: a player who died while a 10s OVERDRIVE (2× score) or MAGNET buff was active would start their next run still carrying that buff for its remaining duration. Added a `PowerUps.reset()` and wired it into both reset points alongside the orb-array fixes.

## Test plan

- [x] `node --check` on all modified files
- [x] `npx jest` — 175/175 passing (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox — same as every prior round)
- [x] `npx eslint script.js` — identical 38 problems before/after the orb/buff-state commit (16 errors unchanged; one `prefer-const` warning dropped since `lightningOrbs` is now legitimately reassigned by its own reset) — no new issues introduced by either commit
- [x] Playwright smoke test: served over `python3 -m http.server`, loaded `index.html`, started a live run via `window.__VOID_RIFT__.startGame()`, confirmed `collect_fragments` appears in `window.missionSystem.dailyMissions` on one rotation, ran several seconds of gameplay with zero *new* console/page errors — confirmed the pre-existing errors (`ERR_TUNNEL_CONNECTION_FAILED` from network-blocked external resources, plus the known `auth-system.js`/`leaderboard-system.js` syntax errors already being fixed by #135/#133) are byte-identical between the base commit and this branch
- [ ] Manual playtest of the Freeze Orb magnet feel and the boss-enrage/orb/buff reset timing in a live run — these are timing-window bugs (only observable when dying at a specific moment) that aren't practically reachable through the exposed debug hooks without new instrumentation; verified via code review, static checks, and the automated smoke test above (recommend a quick playthrough before merge)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014aLiD7PfCwpGJP1hCBEuZC

---
_Generated by [Claude Code](https://claude.ai/code/session_014aLiD7PfCwpGJP1hCBEuZC)_