### PR TITLE
Daily improvement loop: named bounty rewards, wave-1 enemy count, Magnet Range wiring, fragment pickup leak, Daily Challenge RNG leak

### DIFF
--- a/script.js
+++ b/script.js
@@ -2277,6 +2277,7 @@
     timeWarpExpiry = 0;
     overchargeBoostMultiplier = 1;
     overchargeBoostExpiry = 0;
+    if (window.techFragmentSystem) window.techFragmentSystem.clearActivePickups();
     spawners = [];
     particles = [];
     obstacles = [];
@@ -9165,7 +9166,12 @@
       for (let i = 0; i < 5; i++) {
         dropCoin(enemy.x + rand(-30, 30), enemy.y + rand(-30, 30));
       }
-      const bountyReward = Math.floor(30 + level * 8);
+      // Named Mission Board bounties advertise a specific reward (see the Hangar's
+      // Active Bounties cards); anonymous bounty spawns fall back to the generic
+      // level-scaled formula since they have no BOUNTY_TARGETS entry to draw from.
+      const namedBountyDef = enemy.bountyId && window.BOUNTY_TARGETS
+        ? window.BOUNTY_TARGETS.find(b => b.id === enemy.bountyId) : null;
+      const bountyReward = namedBountyDef ? namedBountyDef.reward : Math.floor(30 + level * 8);
       Save.addCredits(bountyReward);
       if (window.missionSystem) window.missionSystem.trackCredits(bountyReward);
       bountyKilledTotal++;
@@ -10476,6 +10482,11 @@
 
     for (const enemy of enemies) enemy.update(dt);
 
+    // Magnet Range shop upgrade (Save.getUpgradeLevel('magnet')) adds on top of the
+    // base drift radius for both coins and supplies below — previously computed
+    // (as Player#dynamicStats' pickupR) but never actually applied to pickups.
+    const magnetBonus = Save.getUpgradeLevel('magnet') * 14 * getAdaptiveScaling().powerEffectiveness;
+
     for (let i = coins.length - 1; i >= 0; i--) {
       const coin = coins[i];
       if (now - coin.created > BASE.COIN_LIFETIME) {
@@ -10483,7 +10494,7 @@
         continue;
       }
       const magnetActive = PowerUps.isMagnetActive(now);
-      const pickupRadius = (player ? player.size + 80 : 120) * (magnetActive ? 6 : 1);
+      const pickupRadius = (player ? player.size + 80 + magnetBonus : 120) * (magnetActive ? 6 : 1);
       const dx = player.x - coin.x;
       const dy = player.y - coin.y;
       const dist = Math.hypot(dx, dy);
@@ -10515,7 +10526,7 @@
       const dx = player.x - crate.x;
       const dy = player.y - crate.y;
       const dist = Math.hypot(dx, dy);
-      if (dist < player.size + 120) {
+      if (dist < player.size + 120 + magnetBonus) {
         crate.x += (dx / (dist || 1)) * 1.6;
         crate.y += (dy / (dist || 1)) * 1.6;
       }
@@ -10944,6 +10955,7 @@
     timeWarpExpiry = 0;
     overchargeBoostMultiplier = 1;
     overchargeBoostExpiry = 0;
+    if (window.techFragmentSystem) window.techFragmentSystem.clearActivePickups();
     spawners = [];
     particles = [];
     bossActive = false;
@@ -12306,10 +12318,12 @@
     waveCreditsEarned = 0;
     // Use the improved scaling with difficulty
     const diff = getDifficulty();
-    // Progressive enemy count calculation
+    // Progressive enemy count calculation — kept in sync with advanceLevel()'s
+    // early-game formula (12 + level * 3.5), which superseded the old 8 + level * 2.5
+    // scaling; this is the only place level 1's enemiesToKill is computed.
     let baseEnemies;
     if (level <= ADAPTIVE_CONSTANTS.EASY_LEVELS) {
-      baseEnemies = Math.floor((8 + level * 2.5) * diff.enemiesToKill);
+      baseEnemies = Math.floor((12 + level * 3.5) * diff.enemiesToKill);
     } else if (level <= ADAPTIVE_CONSTANTS.LATE_GAME_START) {
       baseEnemies = Math.floor((10 + level * 5.5) * diff.enemiesToKill);
     } else {
@@ -12661,10 +12675,17 @@
     setTimeout(() => {
       // Reset runtime state
       resetRuntimeState();
-      
+
+      // Quitting a Daily Challenge run without dying skips handleGameOver(),
+      // which is the only other place Math.random's seeded override gets
+      // restored — leaving it seeded for every subsequent run otherwise.
+      if (window.DAILY_CHALLENGE_ACTIVE) {
+        import('./daily-challenge.js').then(({ deactivateDailyChallenge }) => deactivateDailyChallenge());
+      }
+
       // Return to main menu
       returnToMainMenu();
-      
+
       isExiting = false;
     }, 500);
   };
@@ -14819,6 +14840,11 @@
     
     document.getElementById('menuExitBtn')?.addEventListener('click', () => {
       closeUnifiedMenu();
+      // Same DAILY_CHALLENGE_ACTIVE leak as exitToMainMenu(): quitting here
+      // without dying also skips handleGameOver()'s Math.random restore.
+      if (window.DAILY_CHALLENGE_ACTIVE) {
+        import('./daily-challenge.js').then(({ deactivateDailyChallenge }) => deactivateDailyChallenge());
+      }
       returnToMainMenu();
     });
     


### PR DESCRIPTION
## Summary

Five small, self-contained improvements continuing the daily Void Rift improvement loop. Five prior rounds (**#132, #133, #134, #135, #136**) are still open/unmerged; this round's diffs were read in full and cross-checked line-by-line to avoid any overlap with what they already claim (Base Mods bridging, fragment persistence, bounty behaviors, mission xpBoost/credits/COLLECT_FRAGMENTS templates, Seeker Swarm homing, duplicate listeners, HERALD OF VOID ordering, ultimate effects, auth/leaderboard syntax errors, Prestige, Void Shield/Clone Bay, achievement categories, shop upgrade wiring for crit/armor/cooldown/pierce/ultimate/luck, orb/buff resets, Freeze Orb magnet).

- **fix: named Bounty Target kills paid a generic reward instead of the advertised one.** Each `BOUNTY_TARGETS` entry (`MissionSystem.js`) defines a specific `reward` (450–700 CR) that the Hangar's Missions tab already previews on its Active Bounties cards (added in #129). The actual kill payout in `script.js` ignored it entirely and used a disconnected `Math.floor(30 + level * 8)` formula instead — so the credit reward shown to players never matched what they got. Now looks up the bounty by `enemy.bountyId` and pays its real `reward`; anonymous (non-named) bounty spawns keep the old generic formula since they have no `BOUNTY_TARGETS` entry.
- **fix: wave 1 used a stale, pre-rebalance enemy-count formula.** A comment at `advanceLevel()` documents an intentional change from `8 + level * 2.5` to `12 + level * 3.5` ("INCREASED... to make levels less trivial"), but `startLevel()` — the function that sets up every run's level 1 — still had the old formula, since it's a separate duplicated calculation. Every run's first wave required noticeably fewer kills than the rebalance intended.
- **fix: "Magnet Range" shop upgrade had zero effect on pickup radius.** It's a real, credit-costed upgrade (up to level 8) described as "Increase pickup radius for coins and supplies," and `Player#dynamicStats()` does compute a `pickupR` stat from it — but the only place that stat was ever read was the unrelated Repulse Field push-away radius calc. The actual coin/supply magnetism used flat hardcoded radii (`player.size + 80` / `player.size + 120`) with no reference to the upgrade at all. Now applies an additive `magnetBonus` (derived from `Save.getUpgradeLevel('magnet')`) to both.
- **fix: Tech Fragment world pickups were never cleared between waves or runs.** Unlike every other pickup type (coins, supplies, all 5 orb arrays), `TechFragmentSystem.active` was untouched by both `resetRuntimeState()` (run restart) and `advanceLevel()`'s wave-transition reset. `clearActivePickups()` already existed and is unit-tested (`tech-fragment-system.test.js`) but was never called from `script.js` — fragment pickups could persist on screen across a run restart or level change.
- **fix: Daily Challenge's seeded `Math.random()` override leaked into normal gameplay.** `activateDailyChallenge()` overrides the global `Math.random` with a deterministic per-date PRNG; the only place it was ever restored was `handleGameOver()`. Quitting a Daily Challenge run early via "Exit to Main Menu" — from either the pause menu (`exitToMenuBtn`) or the in-run unified menu (`menuExitBtn`) — skipped that restore entirely, leaving `Math.random` permanently seeded (until a page reload) for every subsequent action: enemy spawns, loot rolls, bounty spawn chance, orb drops, even later *non-daily* runs.

## Test plan

- [x] `node --check script.js`
- [x] `npx jest` — 175/175 passing (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox — same as every prior round)
- [x] `npx eslint script.js hangar-ui.js` — identical 40 problems (17 errors / 23 warnings) before and after this change; no new issues introduced
- [x] Playwright smoke test: served over `python3 -m http.server`, loaded `index.html`, started a live run via `window.__VOID_RIFT__.startGame()`, confirmed identical pre-existing console/page errors before and after this branch (network-blocked external resources, plus the known `auth-system.js`/`leaderboard-system.js` syntax errors already being fixed by #135/#133)
- [x] Live API verification in a real Chromium page: confirmed `window.BOUNTY_TARGETS` reward values match what's now paid on kill; confirmed `Save.getUpgradeLevel('magnet')` feeds the new pickup-radius bonus; spawned a real tech-fragment pickup via `techFragmentSystem.spawnPickup()`, activated the Daily Challenge, opened the pause menu, and clicked "Exit to Main Menu" — confirmed `window.DAILY_CHALLENGE_ACTIVE` flips to `false` and the fragment pickup is cleared
- [ ] Manual playtest of the Magnet Range feel at higher levels and the named-bounty reward payout in a live run — recommend a quick playthrough before merge

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016h8p8dnm2RpT8Q3ZRTcRQa

---
_Generated by [Claude Code](https://claude.ai/code/session_016h8p8dnm2RpT8Q3ZRTcRQa)_