### PR TITLE
Daily improvement loop: Daily Challenge reseed, Quantum Drive duration, difficulty-lock fix, mission-claim persistence, dead double-tap handler

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -2249,6 +2249,14 @@ function renderSettingsView() {
       dailyBtn.textContent = 'Launching…';
       import('./daily-challenge.js').then(({ activateDailyChallenge }) => {
         activateDailyChallenge();
+        // Lock difficulty to normal for a level playing field — startGame()
+        // reads Save.data.difficulty, so it must be set here directly.
+        if (window.Save && window.Save.data) {
+          window.Save.data.difficulty = 'normal';
+          window.Save.save();
+        }
+        const diffSelect = document.getElementById('difficultySelect');
+        if (diffSelect) diffSelect.value = 'normal';
         // Close the Hangar overlay, then trigger game start
         closeHangar();
         setTimeout(() => {
@@ -2708,6 +2716,14 @@ function renderMissionsView() {
       const reward = ms.claimMissionReward(missionId);
       if (!reward) return;
 
+      // Persist the claimed flag immediately — the only other writers of this
+      // key are in-run hooks in script.js, so without this a reload before the
+      // next run/kill reloads the pre-claim state and the reward can be
+      // claimed again.
+      try {
+        localStorage.setItem('voidrift_missions', JSON.stringify(ms.getSaveData()));
+      } catch (e) { /* storage unavailable */ }
+
       // Attempt to add credits via the external handler (bridges into the main
       // game's Save balance) or fall back to the hangar's own internal pool.
       if (typeof _options.addCredits === 'function') {
@@ -2735,6 +2751,9 @@ function renderMissionsView() {
         const fragment = tfs.rollDrop(true, false) || (window.TECH_FRAGMENTS || [])[0];
         if (fragment) {
           tfs.collect(fragment.id);
+          try {
+            localStorage.setItem('voidrift_techfragments', JSON.stringify(tfs.getSaveData()));
+          } catch (e) { /* storage unavailable */ }
           if (window.missionSystem) window.missionSystem.trackFragments(1);
           const style = RARITY_STYLES[fragment.rarity] || {};
           showAchievementToast({ icon: style.emoji || '💎', name: fragment.name, desc: 'Mission reward fragment collected!' });

--- a/index.html
+++ b/index.html
@@ -850,7 +850,14 @@
 
       btn.addEventListener('click', () => {
         activateDailyChallenge();
-        // Lock difficulty to normal for a level playing field
+        // Lock difficulty to normal for a level playing field. Game start
+        // reads Save.data.difficulty, not the <select> element, so the
+        // select's value must be assigned via the saved data (setting
+        // .value alone doesn't fire 'change' and never reaches Save.data).
+        if (window.Save && window.Save.data) {
+          window.Save.data.difficulty = 'normal';
+          window.Save.save();
+        }
         const diffSelect = document.getElementById('difficultySelect');
         if (diffSelect) diffSelect.value = 'normal';
         document.getElementById('startButton').click();

--- a/script.js
+++ b/script.js
@@ -932,6 +932,7 @@
   // Equipment interaction system - Enhanced secondary weapons dock
   let lastTapTime = 0;
   let tapCount = 0;
+  let lastTapSlot = null;
   let currentEquipmentSlot = 0; // 0=primary, 1=slot2, 2=slot3, 3=slot4
   const TAP_TIMEOUT = 500; // ms between taps
   const LONG_PRESS_THRESHOLD = 300; // ms for long-press to open radial menu
@@ -12958,13 +12959,28 @@ PowerUps.reset();
     setTimeout(() => {
       // Hide pause menu
       hidePauseMenu();
-      
+
       // Restart from level 1
       resetRuntimeState();
       runStartTime = performance.now();
       initShipSelection();
-      startLevel(1, true);
-      
+
+      const beginLevel = () => startLevel(1, true);
+
+      // A Daily Challenge run must replay the exact same seeded sequence
+      // every time. Deactivating first restores the true Math.random
+      // before re-seeding, so the reset isn't corrupted by whatever the
+      // already-consumed seeded stream left behind.
+      if (window.DAILY_CHALLENGE_ACTIVE) {
+        import('./daily-challenge.js').then(({ deactivateDailyChallenge, activateDailyChallenge }) => {
+          deactivateDailyChallenge();
+          activateDailyChallenge();
+          beginLevel();
+        });
+      } else {
+        beginLevel();
+      }
+
       isRestarting = false;
     }, 500);
   };
@@ -13947,7 +13963,11 @@ PowerUps.reset();
       // Load saved mission state if available
       try {
         const savedMissions = JSON.parse(localStorage.getItem('voidrift_missions') || 'null');
-        if (savedMissions) window.missionSystem.load(savedMissions);
+        // load() expects its own getSaveData() shape wrapped under `missions`
+        // (mirrors the TechFragmentSystem load/save convention below) — passing
+        // the raw object silently no-ops the restore and every claim/progress
+        // reset on reload.
+        if (savedMissions) window.missionSystem.load({ missions: savedMissions });
         else window.missionSystem.checkDailyRefresh();
       } catch(e) {
         window.missionSystem.checkDailyRefresh();
@@ -14331,15 +14351,20 @@ PowerUps.reset();
         addLogEntry(`Primary weapon active`, '#fde047');
         break;
         
-      case 'boost':
+      case 'boost': {
+        const tfs = window.techFragmentSystem;
+        const unlocks = window.TECH_UNLOCKS || {};
+        const quantumDriveDurationMult = (tfs && tfs.hasFragment('quantum_core') && unlocks.quantum_drive)
+          ? unlocks.quantum_drive.stats.boostDuration : 1;
         input.isBoosting = true;
-        setTimeout(() => (input.isBoosting = false), 300);
+        setTimeout(() => (input.isBoosting = false), 300 * quantumDriveDurationMult);
         addLogEntry(`BOOST activated!`, '#4ade80');
         // Play boost sound
         if (typeof AudioManager !== 'undefined') {
           AudioManager.playBoost();
         }
         break;
+      }
         
       case 'secondary':
         input.altFireHeld = true;
@@ -14649,20 +14674,36 @@ PowerUps.reset();
       return;
     }
     
-    // Single tap - show preview and select
+    // Single tap - show preview and select; a second tap on the same slot
+    // within 300ms equips it immediately. This has to live here rather than
+    // in a 'click' listener: handleEquipSlotPointerDown cancels pointerdown,
+    // which suppresses the browser's synthesized click for the interaction.
     if (state.pointerStartPos && !state.isLongPressing) {
       const slotIndex = parseInt(e.currentTarget?.dataset?.slot ?? state.dragStartSlot);
-      
-      // Show preview
-      showWeaponPreview(slotIndex);
-      
-      // Visual highlight
-      document.querySelectorAll('.equip-slot').forEach((slot, index) => {
-        slot.classList.toggle('preview', index === slotIndex && index !== currentEquipmentSlot);
-      });
-      
-      triggerHapticFeedback('select');
-      markInteraction();
+      const now = performance.now();
+
+      if (slotIndex === lastTapSlot && now - lastTapTime < 300 && tapCount >= 1) {
+        switchEquipmentSlot(slotIndex);
+        triggerHapticFeedback('equip');
+        tapCount = 0;
+        lastTapSlot = null;
+        markInteraction();
+      } else {
+        // Show preview
+        showWeaponPreview(slotIndex);
+
+        // Visual highlight
+        document.querySelectorAll('.equip-slot').forEach((slot, index) => {
+          slot.classList.toggle('preview', index === slotIndex && index !== currentEquipmentSlot);
+        });
+
+        triggerHapticFeedback('select');
+        markInteraction();
+
+        lastTapTime = now;
+        lastTapSlot = slotIndex;
+        tapCount = 1;
+      }
     }
     
     state.isLongPressing = false;
@@ -14690,35 +14731,6 @@ PowerUps.reset();
     state.isLongPressing = false;
     state.pointerStartPos = null;
     state.activePointerId = null;
-  };
-  
-  // Equipment slot click handler (for single tap equip action)
-  const handleEquipSlotClick = (e, slotIndex) => {
-    if (!canInteract()) return;
-    if (equipmentInteractionState.isDragging || equipmentInteractionState.isLongPressing) return;
-    
-    // Double-click to equip immediately
-    const now = performance.now();
-    if (now - lastTapTime < 300 && tapCount >= 1) {
-      // Double tap - equip immediately
-      switchEquipmentSlot(slotIndex);
-      triggerHapticFeedback('equip');
-      tapCount = 0;
-      markInteraction();
-      return;
-    }
-    
-    lastTapTime = now;
-    tapCount++;
-    
-    // Clear tap count after timeout
-    setTimeout(() => {
-      if (performance.now() - lastTapTime >= 300) {
-        tapCount = 0;
-      }
-    }, 300);
-    
-    markInteraction();
   };
   
   // Keyboard navigation for equipment slots
@@ -14787,8 +14799,7 @@ PowerUps.reset();
     slots.forEach((slot, index) => {
       // Pointer events for unified touch/mouse handling
       slot.addEventListener('pointerdown', (e) => handleEquipSlotPointerDown(e, index));
-      slot.addEventListener('click', (e) => handleEquipSlotClick(e, index));
-      
+
       // Focus handling for keyboard navigation
       slot.addEventListener('focus', () => {
         equipmentInteractionState.keyboardFocusIndex = index;


### PR DESCRIPTION
## Summary

Five bugs found and fixed as part of the recurring daily improvement pass over the Void Rift codebase:

- **Daily Challenge restart doesn't re-seed the RNG** (`script.js`, `restartGame`): the pause-menu "Restart" handler never re-armed the Daily Challenge's seeded `Math.random`, so a restarted run diverged from the canonical seeded sequence — breaking the "same run for everyone" guarantee. It now deactivates and re-activates the Daily Challenge seed (when active) before starting level 1.
- **Quantum Drive's boost-duration bonus was never applied** (`script.js`, equipment-dock `boost` case): the tech fragment reward is described as "+35% boost speed **and duration**", but only `boostSpeed` was ever read anywhere. The boost activation's hardcoded 300ms window is now scaled by `boostDuration` when the fragment is owned.
- **"Lock difficulty to normal" for Daily Challenge was a no-op** (`index.html` start button, `hangar-ui.js` quick-launch button): both handlers only set the `<select>` element's `.value`, which doesn't fire a `change` event and never reaches `Save.data.difficulty` — the field `startGame()` actually reads. Both entry points now write `Save.data.difficulty` directly so the Daily Challenge is actually played on a level difficulty for everyone.
- **Mission reward claims from the Hangar weren't persisted** (`hangar-ui.js`): claiming a mission's credits/XP boost/fragment updated `MissionSystem`/`TechFragmentSystem` in memory only. A reload before the next run or kill reloaded the stale pre-claim state from `localStorage`, silently un-claiming the mission and letting the reward be claimed again. The claim handler now persists both systems' state immediately. Fixing this exposed a matching bug in `MissionSystem.load()`, which expected a `{ missions: ... }` wrapper that no save call site ever actually produced — mission progress was silently never restored on page reload. The load call site now wraps its payload to match `getSaveData()`'s shape.
- **Equip-slot dock's double-tap-to-equip was dead code** (`script.js`): the dock's `pointerdown` handler calls `preventDefault()`, which suppresses the browser's synthesized `click` event for that interaction — so the `click`-based double-tap detection could never fire. Moved tap-tracking into the `pointerup` handler, where the gesture is actually observable, and removed the now-unreachable `click` listener/handler.

## Test plan
- [x] `node -c` syntax check on all modified files
- [x] `npx jest` — 175/175 relevant tests pass (the one failing suite, `leaderboard-api.test.js`, fails on a pre-existing missing `@vercel/kv` devDependency unrelated to this change)
- [ ] Manual verification in a browser (not run in this environment)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01CH9XPFPaYiP8vuRT1adiPS)_