### PR TITLE
Daily improvement loop: real AdMob rewarded ads, StoreKit IAP, Void Surge skip fix, dead web login, music not stopping

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.2'
+          xcode-version: '16.2'
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -129,14 +129,25 @@ jobs:
             echo "No Podfile found, skipping pod install"
           fi
 
+      - name: Cache Swift Package dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/.spm-cache
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('ios/VoidRift.xcodeproj/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Build iOS app (Debug)
         working-directory: ios
         run: |
           xcodebuild \
             -project VoidRift.xcodeproj \
             -scheme VoidRift \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
+            -clonedSourcePackagesDirPath .spm-cache \
             clean build \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
@@ -176,7 +187,17 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.2'
+          xcode-version: '16.2'
+
+      - name: Cache Swift Package dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/.spm-cache
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('ios/VoidRift.xcodeproj/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Import Code-Signing Certificates (if available)
         run: |
@@ -254,6 +275,7 @@ jobs:
               -scheme VoidRift \
               -configuration Release \
               -archivePath $RUNNER_TEMP/VoidRift.xcarchive \
+              -clonedSourcePackagesDirPath .spm-cache \
               -allowProvisioningUpdates ${ASC_AUTH_ARGS:-} \
               archive
           else
@@ -262,6 +284,7 @@ jobs:
               -scheme VoidRift \
               -configuration Release \
               -archivePath $RUNNER_TEMP/VoidRift.xcarchive \
+              -clonedSourcePackagesDirPath .spm-cache \
               archive \
               CODE_SIGN_IDENTITY="" \
               CODE_SIGNING_REQUIRED=NO \

--- a/ios/VoidRift.xcodeproj/project.pbxproj
+++ b/ios/VoidRift.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		AA0010 /* GameCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0011 /* GameCenterManager.swift */; };
 		AA0011 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BB0012 /* PrivacyInfo.xcprivacy */; };
 		AA0012 /* AdMobManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0013 /* AdMobManager.swift */; };
+		AA0013 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = KK0001 /* GoogleMobileAds */; };
+		AA0014 /* IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0015 /* IAPManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +39,7 @@
 		BB0012 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BB0013 /* AdMobManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdMobManager.swift; sourceTree = "<group>"; };
 		BB0014 /* VoidRift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VoidRift.entitlements; sourceTree = "<group>"; };
+		BB0015 /* IAPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA0013 /* GoogleMobileAds in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,6 +93,7 @@
 				BB0006 /* OrientationManager.swift */,
 				BB0011 /* GameCenterManager.swift */,
 				BB0013 /* AdMobManager.swift */,
+				BB0015 /* IAPManager.swift */,
 			);
 			path = Native;
 			sourceTree = "<group>";
@@ -127,6 +132,9 @@
 			dependencies = (
 			);
 			name = VoidRift;
+			packageProductDependencies = (
+				KK0001 /* GoogleMobileAds */,
+			);
 			productName = VoidRift;
 			productReference = AAAAAA /* VoidRift.app */;
 			productType = "com.apple.product-type.application";
@@ -160,6 +168,9 @@
 				Base,
 			);
 			mainGroup = DD0001;
+			packageReferences = (
+				JJ0001 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
+			);
 			productRefGroup = DD0003 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -196,6 +207,7 @@
 				AA0006 /* OrientationManager.swift in Sources */,
 				AA0010 /* GameCenterManager.swift in Sources */,
 				AA0012 /* AdMobManager.swift in Sources */,
+				AA0014 /* IAPManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -405,6 +417,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		JJ0001 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
+			requirement = {
+				kind = exactVersion;
+				version = 13.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		KK0001 /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = JJ0001 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = GG0001 /* Project object */;
 }

--- a/ios/VoidRift/Native/AdMobManager.swift
+++ b/ios/VoidRift/Native/AdMobManager.swift
@@ -1,41 +1,101 @@
 import UIKit
+import GoogleMobileAds
 
 /**
  * AdMobManager — VOID RIFT iOS
  *
- * Stub implementation for App Store builds until a real AdMob App ID +
- * Google Mobile Ads SPM package are configured.
+ * Manages rewarded ads via Google Mobile Ads SDK.
  *
- * When ads are ready for production:
- * 1. Add package: https://github.com/googleads/swift-package-manager-google-mobile-ads.git
- * 2. Set GADApplicationIdentifier in Info.plist
- * 3. Restore GoogleMobileAds import + GADRewardedAd loading with production unit IDs
+ * SETUP REQUIRED before App Store submission:
+ * 1. GoogleMobileAds is already wired up as a Swift Package dependency
+ *    (see project.pbxproj) and GADApplicationIdentifier is set in Info.plist.
+ * 2. Replace the test GADApplicationIdentifier in Info.plist with your real
+ *    AdMob App ID from https://admob.google.com/.
+ * 3. Replace the ad unit ID below with your real rewarded ad unit ID.
  *
- * JS bridge still works: preload/show call through, rewards are denied (no free credit).
+ * Test IDs (use during development — REPLACE before App Store submission):
+ *   App ID:  ca-app-pub-3940256099942544~1458002511
+ *   Ad Unit: ca-app-pub-3940256099942544/1712485313
  */
 
 class AdMobManager: NSObject {
 
     static let shared = AdMobManager()
 
-    private var isReady = false
+    // MARK: - Configuration
+    // Replace with your real rewarded ad unit ID from https://admob.google.com/
+    private let rewardedAdUnitID = "ca-app-pub-3940256099942544/1712485313" // TEST ID
 
+    // MARK: - State
+    private var rewardedAd: RewardedAd?
+    private var rewardCallback: ((Bool) -> Void)?
+
+    // MARK: - Init
     private override init() {
         super.init()
-        print("[AdMob] Stub manager active — ads disabled until production SDK is wired")
+        // Initialize the Mobile Ads SDK
+        MobileAds.shared.start(completionHandler: nil)
     }
 
+    // MARK: - Preload
     func preloadRewarded() {
-        isReady = false
-        print("[AdMob] preloadRewarded (stub) — no ad loaded")
+        guard rewardedAd == nil else { return } // Already loaded
+
+        let request = Request()
+        RewardedAd.load(with: rewardedAdUnitID, request: request) { [weak self] ad, error in
+            if let error = error {
+                print("[AdMob] Failed to load rewarded ad: \(error.localizedDescription)")
+                return
+            }
+            self?.rewardedAd = ad
+            self?.rewardedAd?.fullScreenContentDelegate = self
+            print("[AdMob] Rewarded ad loaded ✅")
+
+            // Notify JS that ad is ready
+            NotificationCenter.default.post(name: .adLoaded, object: nil)
+        }
     }
 
+    // MARK: - Show
     func showRewarded(from viewController: UIViewController?, completion: @escaping (Bool) -> Void) {
-        print("[AdMob] showRewarded (stub) — no ad available")
-        completion(false)
+        guard let ad = rewardedAd, let vc = viewController else {
+            print("[AdMob] Ad not ready or no view controller")
+            completion(false)
+            return
+        }
+
+        self.rewardCallback = completion
+
+        ad.present(from: vc) {
+            print("[AdMob] Reward earned ✅")
+            completion(true)
+        }
+
+        // Clear the ad reference after presenting — a new one will be preloaded on dismiss
+        self.rewardedAd = nil
     }
 }
 
+// MARK: - FullScreenContentDelegate
+extension AdMobManager: FullScreenContentDelegate {
+
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        print("[AdMob] Ad dismissed")
+        // Preload next ad
+        rewardedAd = nil
+        preloadRewarded()
+    }
+
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        print("[AdMob] Ad failed to present: \(error.localizedDescription)")
+        rewardCallback?(false)
+        rewardCallback = nil
+        rewardedAd = nil
+        preloadRewarded()
+    }
+}
+
+// MARK: - Notification Names
 extension Notification.Name {
     static let adLoaded = Notification.Name("AdMobAdLoaded")
 }

--- a/ios/VoidRift/Native/GameBridge.swift
+++ b/ios/VoidRift/Native/GameBridge.swift
@@ -35,6 +35,10 @@ class GameBridge: NSObject {
         webView.configuration.userContentController.add(self, name: "adPreloadRewarded")
         webView.configuration.userContentController.add(self, name: "adShowRewarded")
 
+        // In-App Purchase message handlers
+        webView.configuration.userContentController.add(self, name: "iapPurchase")
+        webView.configuration.userContentController.add(self, name: "iapRestore")
+
         // Inject bridge script
         injectBridgeScript()
     }
@@ -188,6 +192,11 @@ extension GameBridge: WKScriptMessageHandler {
             AdMobManager.shared.preloadRewarded()
         case "adShowRewarded":
             handleAdShowRewarded()
+        // In-App Purchase handlers
+        case "iapPurchase":
+            handleIAPPurchase(message.body)
+        case "iapRestore":
+            handleIAPRestore()
         default:
             break
         }
@@ -274,6 +283,50 @@ extension GameBridge: WKScriptMessageHandler {
                 self?.webView?.evaluateJavaScript(js, completionHandler: nil)
             }
         }
+    }
+
+    // MARK: - In-App Purchase Handlers
+
+    private func handleIAPPurchase(_ body: Any) {
+        let data = body as? [String: Any]
+        let productId = (data?["productId"] as? String) ?? IAPManager.removeAdsProductID
+
+        Task { [weak self] in
+            let result = await IAPManager.shared.purchase(productId: productId)
+            let js: String
+            switch result {
+            case .success:
+                js = "window.dispatchEvent(new CustomEvent('iapPurchased', {detail:{productId:'\(GameBridge.jsEscape(productId))'}}));"
+            case .cancelled:
+                js = "window.dispatchEvent(new CustomEvent('iapFailed', {detail:{productId:'\(GameBridge.jsEscape(productId))', reason:'cancelled'}}));"
+            case .failed(let reason):
+                js = "window.dispatchEvent(new CustomEvent('iapFailed', {detail:{productId:'\(GameBridge.jsEscape(productId))', reason:'\(GameBridge.jsEscape(reason))'}}));"
+            }
+            DispatchQueue.main.async {
+                self?.webView?.evaluateJavaScript(js, completionHandler: nil)
+            }
+        }
+    }
+
+    private func handleIAPRestore() {
+        Task { [weak self] in
+            let result = await IAPManager.shared.restore()
+            let js: String
+            switch result {
+            case .success(let ids):
+                let idsJson = (try? JSONSerialization.data(withJSONObject: ids)).flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+                js = "window.dispatchEvent(new CustomEvent('iapRestored', {detail:{productIds: \(idsJson)}}));"
+            case .failed:
+                js = "window.dispatchEvent(new CustomEvent('iapRestoreFailed'));"
+            }
+            DispatchQueue.main.async {
+                self?.webView?.evaluateJavaScript(js, completionHandler: nil)
+            }
+        }
+    }
+
+    private static func jsEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "'", with: "\\'")
     }
 
     // MARK: - Game Center Handlers

--- a/ios/VoidRift/Native/IAPManager.swift
+++ b/ios/VoidRift/Native/IAPManager.swift
@@ -1,0 +1,102 @@
+import StoreKit
+
+/**
+ * IAPManager — VOID RIFT iOS
+ *
+ * Native StoreKit 2 purchase + restore for the "Remove Ads" non-consumable
+ * IAP. Bridged to the web layer's `IAPManager` (hangar-ui.js), which posts
+ * to the `iapPurchase`/`iapRestore` message handlers and listens for the
+ * `iapPurchased` / `iapFailed` / `iapRestored` / `iapRestoreFailed` window
+ * events dispatched back by GameBridge.
+ *
+ * SETUP REQUIRED before App Store submission:
+ * 1. Create the "Remove Ads" non-consumable IAP in App Store Connect with
+ *    product ID `com.voidrift.game.removeads` (must match `removeAdsProductID`
+ *    below and `IAPManager.PRODUCT_ID` in hangar-ui.js).
+ * 2. Test against a StoreKit Configuration file or a Sandbox tester account.
+ */
+
+enum IAPPurchaseResult {
+    case success
+    case cancelled
+    case failed(String)
+}
+
+enum IAPRestoreResult {
+    case success([String])
+    case failed(String)
+}
+
+class IAPManager: NSObject {
+
+    static let shared = IAPManager()
+
+    static let removeAdsProductID = "com.voidrift.game.removeads"
+
+    private var updatesTask: Task<Void, Never>?
+
+    private override init() {
+        super.init()
+        // StoreKit 2 requires observing Transaction.updates even for a single
+        // non-consumable — this catches transactions that complete outside an
+        // explicit purchase() call (e.g. resolved after an app relaunch).
+        updatesTask = Task.detached { [weak self] in
+            for await result in Transaction.updates {
+                await self?.finish(transactionResult: result)
+            }
+        }
+    }
+
+    deinit {
+        updatesTask?.cancel()
+    }
+
+    private func finish(transactionResult: VerificationResult<Transaction>) async {
+        guard case .verified(let transaction) = transactionResult else { return }
+        await transaction.finish()
+    }
+
+    func purchase(productId: String) async -> IAPPurchaseResult {
+        do {
+            let products = try await Product.products(for: [productId])
+            guard let product = products.first else {
+                return .failed("Product not found: \(productId)")
+            }
+
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                switch verification {
+                case .verified(let transaction):
+                    await transaction.finish()
+                    return .success
+                case .unverified:
+                    return .failed("Transaction could not be verified")
+                }
+            case .userCancelled:
+                return .cancelled
+            case .pending:
+                return .failed("Purchase is pending approval")
+            @unknown default:
+                return .failed("Unknown purchase result")
+            }
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    func restore() async -> IAPRestoreResult {
+        do {
+            try await AppStore.sync()
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+
+        var restoredIds: [String] = []
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result else { continue }
+            restoredIds.append(transaction.productID)
+        }
+        return .success(restoredIds)
+    }
+}

--- a/ios/VoidRift/Supporting/Info.plist
+++ b/ios/VoidRift/Supporting/Info.plist
@@ -24,6 +24,12 @@
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- Google Mobile Ads SDK requires this key or it crashes on launch.
+	     This is Google's public test App ID (pairs with the test ad unit ID
+	     in AdMobManager.swift) — replace both with your real AdMob values
+	     from https://admob.google.com/ before App Store submission. -->
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -9696,8 +9696,10 @@ PowerUps.reset();
     if (wasBoss) charge *= 5;
     if (player) player.addUltimateCharge(charge);
     
-    // Check if all enemies eliminated (only for non-boss waves)
-    if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss') {
+    // Check if all enemies eliminated (only for non-boss waves, and never
+    // while a tracked boss entity — incl. the VOID SURGE Herald of Void,
+    // which is tagged 'elite' rather than 'boss' — is still alive)
+    if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss' && !bossActive) {
       addLogEntry('All enemies eliminated!', '#4ade80');
     }
   };
@@ -10999,8 +11001,9 @@ PowerUps.reset();
 
     // Check wave completion (handles boss waves, survival waves, etc.)
     if (!checkWaveCompletion()) {
-      // Normal level advancement for standard/elite/swarm waves
-      if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss') {
+      // Normal level advancement for standard/elite/swarm waves — but never
+      // while a boss entity (incl. the VOID SURGE Herald of Void) is alive
+      if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss' && !bossActive) {
         advanceLevel();
       }
     }
@@ -11360,10 +11363,16 @@ PowerUps.reset();
       }
     }
     
-    if (currentWaveType === 'boss') {
-      // Boss wave ends when boss is dead (removed from enemies array)
+    // Boss waves — generic boss, Leviathan, and the VOID SURGE Herald of Void
+    // (which is tagged currentWaveType 'elite', not 'boss') — all end only
+    // when the tracked boss entity dies, never from the ordinary enemy-kill
+    // quota below. Gating on `bossActive` (rather than currentWaveType)
+    // covers the Herald case: without it, grinding the escort swarm to
+    // enemiesToKill let advanceLevel() delete a still-alive Herald with zero
+    // warning, denying its rewards and the Void Breaker achievement.
+    if (bossActive) {
       // bossEntity is set to null when the boss dies in handleEnemyDeath
-      if (bossActive && !bossEntity) {
+      if (!bossEntity) {
         addLogEntry('🎉 BOSS DEFEATED!', '#4ade80');
         bossActive = false;
         // Give bonus rewards — tracked for post-wave overlay
@@ -11375,10 +11384,10 @@ PowerUps.reset();
         waveCreditsEarned += _bossBonus; // add boss bonus after advanceLevel resets counter
         return true;
       }
-      // Don't advance from normal kills in boss wave
+      // Don't advance from normal kills while the boss is still alive
       return false;
     }
-    
+
     return false;
   };
 
@@ -12903,19 +12912,22 @@ PowerUps.reset();
     if (paused) {
       cancelAnimationFrame(animationFrame);
       showPauseMenu();
+      if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
     } else {
       hidePauseMenu();
       lastTime = performance.now();
       animationFrame = requestAnimationFrame(loop);
+      if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
     }
   };
-  
+
   const resumeGame = () => {
     if (!gameRunning || !paused) return;
     paused = false;
     hidePauseMenu();
     lastTime = performance.now();
     animationFrame = requestAnimationFrame(loop);
+    if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
   };
   
   const exitToMainMenu = () => {
@@ -12964,7 +12976,8 @@ PowerUps.reset();
       runStartTime = performance.now();
       initShipSelection();
       startLevel(1, true);
-      
+      if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
+
       isRestarting = false;
     }, 500);
   };
@@ -13726,6 +13739,8 @@ PowerUps.reset();
   };
 
   const returnToMainMenu = () => {
+    if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
+
     // Close any open modals
     closeGameOverScreen();
     hidePauseMenu();
@@ -14012,6 +14027,7 @@ PowerUps.reset();
       // Auto-pause when tab loses focus
       paused = true;
       cancelAnimationFrame(animationFrame);
+      if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
     }
   });
 

--- a/ios/VoidRift/WebContent/unified-social.js
+++ b/ios/VoidRift/WebContent/unified-social.js
@@ -4,7 +4,7 @@
  * Provides seamless social experience across platforms
  * 
  * @global SocialAPI - Web social API (from social-api.js)
- * @global SocialHub - Web social hub UI (from social-hub.js)
+ * @global SocialUI - Web social/auth UI, the one actually wired up in index.html (from social-ui.js)
  * @global GlobalLeaderboard - Global leaderboard system (from backend-api.js)
  * @global submitSocialScore - Score submission function (from social-integration.js)
  * @global socialGameOver - Game over handler (from social-integration.js)
@@ -12,7 +12,7 @@
  * @global module - Node.js module object
  */
 
-/* global SocialAPI, SocialHub, GlobalLeaderboard, submitSocialScore, socialGameOver, updateSocialUI, module */
+/* global SocialAPI, SocialUI, GlobalLeaderboard, submitSocialScore, socialGameOver, updateSocialUI, module */
 
 const UnifiedSocial = {
   // Platform detection
@@ -178,9 +178,9 @@ const UnifiedSocial = {
     if (this.isGameCenterAuthenticated) {
       // Show native Game Center achievements
       window.iOSBridge.gameCenter.showAchievements();
-    } else if (typeof SocialHub !== 'undefined') {
+    } else if (typeof SocialUI !== 'undefined') {
       // Show web profile with achievements
-      SocialHub.showProfile();
+      SocialUI.showProfileModal();
     }
   },
 
@@ -280,8 +280,8 @@ const UnifiedSocial = {
     } else if (loginBtn) {
       loginBtn.textContent = 'Login';
       loginBtn.onclick = () => {
-        if (typeof SocialHub !== 'undefined') {
-          SocialHub.showAuthModal('login');
+        if (typeof SocialUI !== 'undefined') {
+          SocialUI.showAuthModal('login');
         }
       };
       loginBtn.classList.add('footer-btn-text');
@@ -299,9 +299,9 @@ const UnifiedSocial = {
     if (this.isGameCenterAuthenticated) {
       // Show Game Center profile
       this.showAchievements();
-    } else if (typeof SocialHub !== 'undefined') {
+    } else if (typeof SocialUI !== 'undefined') {
       // Show web profile
-      SocialHub.showProfile();
+      SocialUI.showProfileModal();
     }
   },
 

--- a/script.js
+++ b/script.js
@@ -9696,8 +9696,10 @@ PowerUps.reset();
     if (wasBoss) charge *= 5;
     if (player) player.addUltimateCharge(charge);
     
-    // Check if all enemies eliminated (only for non-boss waves)
-    if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss') {
+    // Check if all enemies eliminated (only for non-boss waves, and never
+    // while a tracked boss entity — incl. the VOID SURGE Herald of Void,
+    // which is tagged 'elite' rather than 'boss' — is still alive)
+    if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss' && !bossActive) {
       addLogEntry('All enemies eliminated!', '#4ade80');
     }
   };
@@ -10999,8 +11001,9 @@ PowerUps.reset();
 
     // Check wave completion (handles boss waves, survival waves, etc.)
     if (!checkWaveCompletion()) {
-      // Normal level advancement for standard/elite/swarm waves
-      if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss') {
+      // Normal level advancement for standard/elite/swarm waves — but never
+      // while a boss entity (incl. the VOID SURGE Herald of Void) is alive
+      if (enemiesKilled >= enemiesToKill && currentWaveType !== 'boss' && !bossActive) {
         advanceLevel();
       }
     }
@@ -11360,10 +11363,16 @@ PowerUps.reset();
       }
     }
     
-    if (currentWaveType === 'boss') {
-      // Boss wave ends when boss is dead (removed from enemies array)
+    // Boss waves — generic boss, Leviathan, and the VOID SURGE Herald of Void
+    // (which is tagged currentWaveType 'elite', not 'boss') — all end only
+    // when the tracked boss entity dies, never from the ordinary enemy-kill
+    // quota below. Gating on `bossActive` (rather than currentWaveType)
+    // covers the Herald case: without it, grinding the escort swarm to
+    // enemiesToKill let advanceLevel() delete a still-alive Herald with zero
+    // warning, denying its rewards and the Void Breaker achievement.
+    if (bossActive) {
       // bossEntity is set to null when the boss dies in handleEnemyDeath
-      if (bossActive && !bossEntity) {
+      if (!bossEntity) {
         addLogEntry('🎉 BOSS DEFEATED!', '#4ade80');
         bossActive = false;
         // Give bonus rewards — tracked for post-wave overlay
@@ -11375,10 +11384,10 @@ PowerUps.reset();
         waveCreditsEarned += _bossBonus; // add boss bonus after advanceLevel resets counter
         return true;
       }
-      // Don't advance from normal kills in boss wave
+      // Don't advance from normal kills while the boss is still alive
       return false;
     }
-    
+
     return false;
   };
 
@@ -12903,19 +12912,22 @@ PowerUps.reset();
     if (paused) {
       cancelAnimationFrame(animationFrame);
       showPauseMenu();
+      if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
     } else {
       hidePauseMenu();
       lastTime = performance.now();
       animationFrame = requestAnimationFrame(loop);
+      if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
     }
   };
-  
+
   const resumeGame = () => {
     if (!gameRunning || !paused) return;
     paused = false;
     hidePauseMenu();
     lastTime = performance.now();
     animationFrame = requestAnimationFrame(loop);
+    if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
   };
   
   const exitToMainMenu = () => {
@@ -12964,7 +12976,8 @@ PowerUps.reset();
       runStartTime = performance.now();
       initShipSelection();
       startLevel(1, true);
-      
+      if (typeof AudioManager !== 'undefined') AudioManager.startMusic();
+
       isRestarting = false;
     }, 500);
   };
@@ -13726,6 +13739,8 @@ PowerUps.reset();
   };
 
   const returnToMainMenu = () => {
+    if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
+
     // Close any open modals
     closeGameOverScreen();
     hidePauseMenu();
@@ -14012,6 +14027,7 @@ PowerUps.reset();
       // Auto-pause when tab loses focus
       paused = true;
       cancelAnimationFrame(animationFrame);
+      if (typeof AudioManager !== 'undefined') AudioManager.stopMusic();
     }
   });
 

--- a/unified-social.js
+++ b/unified-social.js
@@ -4,7 +4,7 @@
  * Provides seamless social experience across platforms
  * 
  * @global SocialAPI - Web social API (from social-api.js)
- * @global SocialHub - Web social hub UI (from social-hub.js)
+ * @global SocialUI - Web social/auth UI, the one actually wired up in index.html (from social-ui.js)
  * @global GlobalLeaderboard - Global leaderboard system (from backend-api.js)
  * @global submitSocialScore - Score submission function (from social-integration.js)
  * @global socialGameOver - Game over handler (from social-integration.js)
@@ -12,7 +12,7 @@
  * @global module - Node.js module object
  */
 
-/* global SocialAPI, SocialHub, GlobalLeaderboard, submitSocialScore, socialGameOver, updateSocialUI, module */
+/* global SocialAPI, SocialUI, GlobalLeaderboard, submitSocialScore, socialGameOver, updateSocialUI, module */
 
 const UnifiedSocial = {
   // Platform detection
@@ -178,9 +178,9 @@ const UnifiedSocial = {
     if (this.isGameCenterAuthenticated) {
       // Show native Game Center achievements
       window.iOSBridge.gameCenter.showAchievements();
-    } else if (typeof SocialHub !== 'undefined') {
+    } else if (typeof SocialUI !== 'undefined') {
       // Show web profile with achievements
-      SocialHub.showProfile();
+      SocialUI.showProfileModal();
     }
   },
 
@@ -280,8 +280,8 @@ const UnifiedSocial = {
     } else if (loginBtn) {
       loginBtn.textContent = 'Login';
       loginBtn.onclick = () => {
-        if (typeof SocialHub !== 'undefined') {
-          SocialHub.showAuthModal('login');
+        if (typeof SocialUI !== 'undefined') {
+          SocialUI.showAuthModal('login');
         }
       };
       loginBtn.classList.add('footer-btn-text');
@@ -299,9 +299,9 @@ const UnifiedSocial = {
     if (this.isGameCenterAuthenticated) {
       // Show Game Center profile
       this.showAchievements();
-    } else if (typeof SocialHub !== 'undefined') {
+    } else if (typeof SocialUI !== 'undefined') {
       // Show web profile
-      SocialHub.showProfile();
+      SocialUI.showProfileModal();
     }
   },
 


### PR DESCRIPTION
## Summary

First day of the 7-day, 35-task plan in `WEEKLY_ROADMAP.md` (from PR #140), covering the Day 1 "stop the bleeding" items:

- **[ios]** Wire a real `GADRewardedAd` implementation into `AdMobManager.swift`. It was a stub that always called `completion(false)` — every "Watch Ad to Continue" / bonus-credit prompt silently failed on real devices. Added `GoogleMobileAds` as a Swift Package dependency (`project.pbxproj`), the required `GADApplicationIdentifier` in `Info.plist`, and bumped CI to Xcode 16.2 with a generic-simulator destination. This reuses the already-iterated, most-vetted fix from the stale open PR #128 (7 commits working through Swift API renames and Xcode/SDK compatibility) instead of re-deriving the same dead ends from scratch.
- **[ios]** Implement native StoreKit 2 purchase + restore for the "Remove Ads" IAP. `GameBridge.swift` never registered `iapPurchase`/`iapRestore` handlers, so `IAPManager.platform` (`hangar-ui.js`) always resolved to `'web'` in the native app and the buy button stayed permanently disabled. Added `ios/VoidRift/Native/IAPManager.swift` and wired the two message handlers to dispatch the `iapPurchased`/`iapFailed`/`iapRestored`/`iapRestoreFailed` window events the existing web-side `IAPManager` already listens for.
- **[gameplay]** Fix the Void Surge skip bug — `checkWaveCompletion()` and the enemy-kill-quota fallback only gated wave advancement on boss death when `currentWaveType === 'boss'`, but Void Surge waves are tagged `'elite'`. Players could grind the escort swarm to the kill quota and `advanceLevel()` would delete the still-alive **HERALD OF VOID** with zero warning, denying its rewards and the Void Breaker achievement. Now gates on `bossActive` (true for generic boss, Leviathan, and the Herald alike) instead of the wave-type string.
- **[social]** Fix web login doing nothing — `unified-social.js`'s `updateSocialUI()`, `showProfile()`, and `showAchievements()` all pointed the `#loginButton` handler and profile/achievements UI at `SocialHub`, which is never `<script>`-included in `index.html` and is therefore always `undefined`, silently swallowing every click. Repointed all three at `SocialUI` (`social-ui.js`), the auth/profile UI that's actually wired up.
- **[audio]** Fix background music never stopping — wired `AudioManager.stopMusic()` into `togglePause()`, the tab-visibility auto-pause handler, and `returnToMainMenu()`, paired with `AudioManager.startMusic()` on resume/restart so music doesn't stay silenced afterward.

## Test plan

- [x] `npx jest` — 175/175 passing (same pre-existing unrelated `@vercel/kv` failure as before this change)
- [x] `npx eslint script.js audio-manager.js unified-social.js` — identical 50 problems (26 errors / 24 warnings) before and after; no new lint issues introduced
- [x] `node -c` on all edited JS files
- [x] Balanced-braces/parens check + full manual re-read of the edited `project.pbxproj` sections
- [x] `python3 plistlib.load()` confirms `Info.plist` is still valid XML
- [x] `python3 yaml.safe_load()` confirms `ios-build.yml` is still valid YAML
- [x] `ios/VoidRift/WebContent/{script.js,unified-social.js}` re-synced via `sync-ios-content.sh` and diffed byte-identical against the root copies
- [ ] Could not run `xcodebuild` directly (no macOS/Xcode toolchain in this sandbox) — **needs a green "Build iOS App" CI run before merging**

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1HHommDYysRMHCAAr3CtG)_