### PR TITLE
Daily improvement loop: ready-up soft-lock, fragment magnet, Flawless Victory, Daily Challenge RNG, Ship Collector

### DIFF
--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -902,6 +902,7 @@
   let pilotLevel = 1;
   let pilotXP = 0;
   let tookDamageThisLevel = false;
+  let hadFlawlessLevelThisRun = false; // set when ANY level this run was cleared without damage
   let lastCloseCallAt = 0;
   let gameOverHandled = false;
   let missionsCompletedThisRun = 0;
@@ -2302,6 +2303,14 @@
   const currentUltimateSystem = () => ARMORY_MAP.ultimate[Save.data.armory.loadout.ultimate] || ARMORY.ultimate[0];
 
   const resetRuntimeState = () => {
+    // A stale ready-up/countdown phase left over from the previous run (e.g.
+    // starting a new game while paused mid-"ready up") would otherwise leave
+    // the main loop stuck forever skipping updateGame() for the new run.
+    readyUpPhase = false;
+    readyUpLevel = 0;
+    countdownActive = false;
+    countdownEnd = 0;
+    countdownCompletedLevel = 0;
     enemies = [];
     bullets = [];
     coins = [];
@@ -2349,6 +2358,7 @@ PowerUps.reset();
     pilotLevel = Save.data.pilotLevel;
     pilotXP = Save.data.pilotXp;
     tookDamageThisLevel = false;
+    hadFlawlessLevelThisRun = false;
     lastCloseCallAt = 0;
     gameOverHandled = false;
     missionsCompletedThisRun = 0;
@@ -10131,6 +10141,14 @@ PowerUps.reset();
       btn.addEventListener('click', () => {
         Save.data.selectedShip = ship.id;
         Save.save();
+        // Ship Collector achievement reads Auth.playerProfile.unlockedShips,
+        // but only prestige rewards ever pushed to it — equipping a ship here
+        // never did, so the achievement was unreachable through normal play.
+        if (!Auth.playerProfile.unlockedShips.includes(ship.id)) {
+          Auth.playerProfile.unlockedShips.push(ship.id);
+          Auth.saveProfile();
+          Auth.checkAchievements();
+        }
         initShipSelection();
         if (player) player.reconfigureLoadout(true);
         drawStartGraphic();
@@ -10256,6 +10274,12 @@ PowerUps.reset();
       selectedShip = shipDef.id;
       Save.data.selectedShip = shipDef.id;
       Save.save();
+      // See createShipCard's Equip handler — same Ship Collector wiring fix.
+      if (!Auth.playerProfile.unlockedShips.includes(shipDef.id)) {
+        Auth.playerProfile.unlockedShips.push(shipDef.id);
+        Auth.saveProfile();
+        Auth.checkAchievements();
+      }
       if (player) player.reconfigureLoadout(true);
       renderHangar();
     });
@@ -10531,7 +10555,12 @@ PowerUps.reset();
     if (window.techFragmentSystem) {
       const tfs = window.techFragmentSystem;
       tfs.update(dt);
-      const collectedPickup = tfs.checkCollection(player.x, player.y, player.size);
+      // checkCollection's 3rd arg is the full magnet range (see TechFragmentSystem
+      // docs) — was passed raw player.size, so fragments never benefited from the
+      // Magnet Range shop upgrade or the MAGNET power-up the way coins/supplies do.
+      const fragmentMagnetBonus = Save.getUpgradeLevel('magnet') * 14 * getAdaptiveScaling().powerEffectiveness;
+      const fragmentMagnetRange = (player.size + fragmentMagnetBonus) * (PowerUps.isMagnetActive(now) ? 3 : 1);
+      const collectedPickup = tfs.checkCollection(player.x, player.y, fragmentMagnetRange);
       if (collectedPickup) {
         if (window.missionSystem) window.missionSystem.trackFragments(1);
         if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
@@ -11054,6 +11083,7 @@ PowerUps.reset();
       window.missionSystem.trackLevelComplete(!tookDamageThisLevel);
     }
     if (!tookDamageThisLevel) {
+      hadFlawlessLevelThisRun = true;
       addXP(110 + level * 18);
       // Perfect Wave bonus — extra credits + announcement
       const perfectBonus = Math.floor(40 + level * 10);
@@ -13027,6 +13057,15 @@ PowerUps.reset();
       
       // Restart from level 1
       resetRuntimeState();
+
+      // Restarting a Daily Challenge run without dying skips handleGameOver(),
+      // which is the only other place Math.random's seeded override gets
+      // restored — leaving it seeded for every subsequent run otherwise (see
+      // the same fix in exitToMainMenu()).
+      if (window.DAILY_CHALLENGE_ACTIVE) {
+        import('./daily-challenge.js').then(({ deactivateDailyChallenge }) => deactivateDailyChallenge());
+      }
+
       runStartTime = performance.now();
       initShipSelection();
       startLevel(1, true);
@@ -13336,7 +13375,11 @@ PowerUps.reset();
       eliteKills: eliteKillsThisRun,
       voidSurgeKills: voidSurgeKilledThisRun,
       playTime: performance.now() - (waveStartTime || performance.now()),
-      flawlessLevel: !tookDamageThisLevel
+      // Was `!tookDamageThisLevel`, evaluated at the moment of death — the
+      // fatal hit itself sets tookDamageThisLevel, so that almost always read
+      // false-flawless even after clearing earlier levels without damage.
+      // hadFlawlessLevelThisRun tracks the whole run, set in advanceLevel().
+      flawlessLevel: hadFlawlessLevelThisRun
     });
 
     // Feed the AchievementSystem lifetime totals so the Hangar's Achievements

--- a/script.js
+++ b/script.js
@@ -902,6 +902,7 @@
   let pilotLevel = 1;
   let pilotXP = 0;
   let tookDamageThisLevel = false;
+  let hadFlawlessLevelThisRun = false; // set when ANY level this run was cleared without damage
   let lastCloseCallAt = 0;
   let gameOverHandled = false;
   let missionsCompletedThisRun = 0;
@@ -2302,6 +2303,14 @@
   const currentUltimateSystem = () => ARMORY_MAP.ultimate[Save.data.armory.loadout.ultimate] || ARMORY.ultimate[0];
 
   const resetRuntimeState = () => {
+    // A stale ready-up/countdown phase left over from the previous run (e.g.
+    // starting a new game while paused mid-"ready up") would otherwise leave
+    // the main loop stuck forever skipping updateGame() for the new run.
+    readyUpPhase = false;
+    readyUpLevel = 0;
+    countdownActive = false;
+    countdownEnd = 0;
+    countdownCompletedLevel = 0;
     enemies = [];
     bullets = [];
     coins = [];
@@ -2349,6 +2358,7 @@ PowerUps.reset();
     pilotLevel = Save.data.pilotLevel;
     pilotXP = Save.data.pilotXp;
     tookDamageThisLevel = false;
+    hadFlawlessLevelThisRun = false;
     lastCloseCallAt = 0;
     gameOverHandled = false;
     missionsCompletedThisRun = 0;
@@ -10131,6 +10141,14 @@ PowerUps.reset();
       btn.addEventListener('click', () => {
         Save.data.selectedShip = ship.id;
         Save.save();
+        // Ship Collector achievement reads Auth.playerProfile.unlockedShips,
+        // but only prestige rewards ever pushed to it — equipping a ship here
+        // never did, so the achievement was unreachable through normal play.
+        if (!Auth.playerProfile.unlockedShips.includes(ship.id)) {
+          Auth.playerProfile.unlockedShips.push(ship.id);
+          Auth.saveProfile();
+          Auth.checkAchievements();
+        }
         initShipSelection();
         if (player) player.reconfigureLoadout(true);
         drawStartGraphic();
@@ -10256,6 +10274,12 @@ PowerUps.reset();
       selectedShip = shipDef.id;
       Save.data.selectedShip = shipDef.id;
       Save.save();
+      // See createShipCard's Equip handler — same Ship Collector wiring fix.
+      if (!Auth.playerProfile.unlockedShips.includes(shipDef.id)) {
+        Auth.playerProfile.unlockedShips.push(shipDef.id);
+        Auth.saveProfile();
+        Auth.checkAchievements();
+      }
       if (player) player.reconfigureLoadout(true);
       renderHangar();
     });
@@ -10531,7 +10555,12 @@ PowerUps.reset();
     if (window.techFragmentSystem) {
       const tfs = window.techFragmentSystem;
       tfs.update(dt);
-      const collectedPickup = tfs.checkCollection(player.x, player.y, player.size);
+      // checkCollection's 3rd arg is the full magnet range (see TechFragmentSystem
+      // docs) — was passed raw player.size, so fragments never benefited from the
+      // Magnet Range shop upgrade or the MAGNET power-up the way coins/supplies do.
+      const fragmentMagnetBonus = Save.getUpgradeLevel('magnet') * 14 * getAdaptiveScaling().powerEffectiveness;
+      const fragmentMagnetRange = (player.size + fragmentMagnetBonus) * (PowerUps.isMagnetActive(now) ? 3 : 1);
+      const collectedPickup = tfs.checkCollection(player.x, player.y, fragmentMagnetRange);
       if (collectedPickup) {
         if (window.missionSystem) window.missionSystem.trackFragments(1);
         if (typeof AudioManager !== 'undefined') AudioManager.playCoinPickup();
@@ -11054,6 +11083,7 @@ PowerUps.reset();
       window.missionSystem.trackLevelComplete(!tookDamageThisLevel);
     }
     if (!tookDamageThisLevel) {
+      hadFlawlessLevelThisRun = true;
       addXP(110 + level * 18);
       // Perfect Wave bonus — extra credits + announcement
       const perfectBonus = Math.floor(40 + level * 10);
@@ -13027,6 +13057,15 @@ PowerUps.reset();
       
       // Restart from level 1
       resetRuntimeState();
+
+      // Restarting a Daily Challenge run without dying skips handleGameOver(),
+      // which is the only other place Math.random's seeded override gets
+      // restored — leaving it seeded for every subsequent run otherwise (see
+      // the same fix in exitToMainMenu()).
+      if (window.DAILY_CHALLENGE_ACTIVE) {
+        import('./daily-challenge.js').then(({ deactivateDailyChallenge }) => deactivateDailyChallenge());
+      }
+
       runStartTime = performance.now();
       initShipSelection();
       startLevel(1, true);
@@ -13336,7 +13375,11 @@ PowerUps.reset();
       eliteKills: eliteKillsThisRun,
       voidSurgeKills: voidSurgeKilledThisRun,
       playTime: performance.now() - (waveStartTime || performance.now()),
-      flawlessLevel: !tookDamageThisLevel
+      // Was `!tookDamageThisLevel`, evaluated at the moment of death — the
+      // fatal hit itself sets tookDamageThisLevel, so that almost always read
+      // false-flawless even after clearing earlier levels without damage.
+      // hadFlawlessLevelThisRun tracks the whole run, set in advanceLevel().
+      flawlessLevel: hadFlawlessLevelThisRun
     });
 
     // Feed the AchievementSystem lifetime totals so the Hangar's Achievements


### PR DESCRIPTION
Continuing the recurring daily improvement loop — five bugs found and fixed in this pass, all in `script.js` (mirrored to `ios/VoidRift/WebContent/script.js`, which is kept byte-identical to the root copy).

## Bugs fixed

1. **Ready-up/countdown soft-lock on new game.** `resetRuntimeState()` never cleared `readyUpPhase`/`countdownActive`/`countdownEnd`/`countdownCompletedLevel`. Starting a new game (or restarting) while a previous run was paused mid "ready up" left those flags stuck true, and the main loop skips `updateGame()` entirely whenever `readyUpPhase` or `countdownActive` is true — freezing the new run.
2. **Tech fragment pickups ignored magnet upgrades.** `checkCollection()`'s third argument is documented as the pickup's full magnet range, but the caller passed raw `player.size`, so fragments never benefited from the Magnet Range shop upgrade or the MAGNET power-up the way coins/supplies already do.
3. **"Flawless Victory" achievement was effectively unreachable.** It read `!tookDamageThisLevel` at the moment of game over — but the fatal hit itself sets `tookDamageThisLevel = true`, so this was almost always false even after the player cleared several earlier levels without taking damage. Now tracked via a new `hadFlawlessLevelThisRun` flag set in `advanceLevel()` (right where the existing Perfect Wave bonus already computes the same condition correctly).
4. **Daily Challenge RNG leak on restart.** `exitToMainMenu()` deactivates the Daily Challenge's seeded `Math.random` override before returning to the menu (with a comment explaining why), but `restartGame()` — reachable from the same pause menu — never did, leaving the seeded RNG active for every subsequent run after a mid-challenge restart.
5. **Ship Collector achievement never fired from normal play.** It reads `Auth.playerProfile.unlockedShips`, but the only code path that ever pushed into that array was prestige rewards. Equipping a ship from the Hangar or the start-screen ship selector — the normal way players use different ships — never updated it.

## Test plan

- [x] `node --check script.js` — syntax OK
- [x] `npx jest` — 175/175 tests pass (pre-existing `leaderboard-api.test.js` failure is unrelated: missing `@vercel/kv`, not a package.json dependency, fails identically on `main`)
- [x] `npx eslint script.js` — same 45 pre-existing warnings/errors before and after this change (verified via `git stash` diff); no new lint issues introduced
- [x] Confirmed root `script.js` and `ios/VoidRift/WebContent/script.js` remain byte-identical after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq2rxSEr7bMnLDa8GQ8Kew

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq2rxSEr7bMnLDa8GQ8Kew)_