### PR TITLE
Daily improvement loop: perk double-dip, duplicate achievement toasts, uncapped damage scaling, particle alpha bug, dead HUD theme picker

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1266,11 +1266,6 @@ const HANGAR_UI_CSS = `
   .hangar-daily-btn:disabled { opacity: 0.5; cursor: default; }
 
   /* ── HUD Theme picker ─────────────────────────────────── */
-  .hangar-theme-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
-  .hangar-theme-swatches { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 10px; }
-  .hangar-theme-swatch { width: 32px; height: 32px; border-radius: 50%; border: 2px solid transparent; cursor: pointer; transition: transform 0.15s, border-color 0.15s; }
-  .hangar-theme-swatch:hover { transform: scale(1.15); }
-  .hangar-theme-swatch.active { border-color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.3); transform: scale(1.1); }
   .hangar-theme-hint { font-size: 11px; color: rgba(255,255,255,0.35); margin-top: 8px; }
 
   /* ── Accessibility section ───────────────────────────────── */
@@ -2131,26 +2126,6 @@ function renderSettingsView() {
         </div>
       </div>
 
-      <div class="hangar-settings-section hangar-theme-section">
-        <div class="hangar-settings-label">🎨 HUD Theme</div>
-        <div class="hangar-theme-swatches" id="hangar-theme-swatches">
-          ${[
-            { id: 'cyan',   color: '#38bdf8', label: 'Cyan (Default)' },
-            { id: 'green',  color: '#4ade80', label: 'Neon Green'     },
-            { id: 'red',    color: '#f87171', label: 'Blood Red'      },
-            { id: 'purple', color: '#a855f7', label: 'Royal Purple'   },
-            { id: 'gold',   color: '#fbbf24', label: 'Gold'           },
-          ].map(t => {
-            const saved = localStorage.getItem('voidrift_hud_theme') || 'cyan';
-            return `<button class="hangar-theme-swatch${saved === t.id ? ' active' : ''}"
-                      data-theme="${t.id}"
-                      style="background:${t.color}"
-                      title="${t.label}"
-                      aria-label="${t.label}"></button>`;
-          }).join('')}
-        </div>
-        <div class="hangar-theme-hint">Applies to mission HUD and status overlays.</div>
-      </div>
       <div class="hangar-settings-section hangar-accessibility-section">
         <div class="hangar-settings-label">👁️ Accessibility</div>
         <div class="hangar-settings-row">
@@ -2273,20 +2248,6 @@ function renderSettingsView() {
     });
   }
 
-  // Wire up HUD theme swatches
-  const swatchContainer = document.getElementById('hangar-theme-swatches');
-  if (swatchContainer) {
-    swatchContainer.addEventListener('click', (e) => {
-      const btn = e.target.closest('.hangar-theme-swatch');
-      if (!btn) return;
-      const themeId = btn.dataset.theme;
-      localStorage.setItem('voidrift_hud_theme', themeId);
-      // Update active state
-      swatchContainer.querySelectorAll('.hangar-theme-swatch').forEach(s => {
-        s.classList.toggle('active', s.dataset.theme === themeId);
-      });
-    });
-  }
 }
 
 /** Persists the selected leaderboard mode across tab re-renders */

--- a/ios/VoidRift/WebContent/hangar-ui.js
+++ b/ios/VoidRift/WebContent/hangar-ui.js
@@ -1266,11 +1266,6 @@ const HANGAR_UI_CSS = `
   .hangar-daily-btn:disabled { opacity: 0.5; cursor: default; }
 
   /* ── HUD Theme picker ─────────────────────────────────── */
-  .hangar-theme-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
-  .hangar-theme-swatches { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 10px; }
-  .hangar-theme-swatch { width: 32px; height: 32px; border-radius: 50%; border: 2px solid transparent; cursor: pointer; transition: transform 0.15s, border-color 0.15s; }
-  .hangar-theme-swatch:hover { transform: scale(1.15); }
-  .hangar-theme-swatch.active { border-color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.3); transform: scale(1.1); }
   .hangar-theme-hint { font-size: 11px; color: rgba(255,255,255,0.35); margin-top: 8px; }
 
   /* ── Accessibility section ───────────────────────────────── */
@@ -2131,26 +2126,6 @@ function renderSettingsView() {
         </div>
       </div>
 
-      <div class="hangar-settings-section hangar-theme-section">
-        <div class="hangar-settings-label">🎨 HUD Theme</div>
-        <div class="hangar-theme-swatches" id="hangar-theme-swatches">
-          ${[
-            { id: 'cyan',   color: '#38bdf8', label: 'Cyan (Default)' },
-            { id: 'green',  color: '#4ade80', label: 'Neon Green'     },
-            { id: 'red',    color: '#f87171', label: 'Blood Red'      },
-            { id: 'purple', color: '#a855f7', label: 'Royal Purple'   },
-            { id: 'gold',   color: '#fbbf24', label: 'Gold'           },
-          ].map(t => {
-            const saved = localStorage.getItem('voidrift_hud_theme') || 'cyan';
-            return `<button class="hangar-theme-swatch${saved === t.id ? ' active' : ''}"
-                      data-theme="${t.id}"
-                      style="background:${t.color}"
-                      title="${t.label}"
-                      aria-label="${t.label}"></button>`;
-          }).join('')}
-        </div>
-        <div class="hangar-theme-hint">Applies to mission HUD and status overlays.</div>
-      </div>
       <div class="hangar-settings-section hangar-accessibility-section">
         <div class="hangar-settings-label">👁️ Accessibility</div>
         <div class="hangar-settings-row">
@@ -2273,20 +2248,6 @@ function renderSettingsView() {
     });
   }
 
-  // Wire up HUD theme swatches
-  const swatchContainer = document.getElementById('hangar-theme-swatches');
-  if (swatchContainer) {
-    swatchContainer.addEventListener('click', (e) => {
-      const btn = e.target.closest('.hangar-theme-swatch');
-      if (!btn) return;
-      const themeId = btn.dataset.theme;
-      localStorage.setItem('voidrift_hud_theme', themeId);
-      // Update active state
-      swatchContainer.querySelectorAll('.hangar-theme-swatch').forEach(s => {
-        s.classList.toggle('active', s.dataset.theme === themeId);
-      });
-    });
-  }
 }
 
 /** Persists the selected leaderboard mode across tab re-renders */

--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -568,7 +568,8 @@
     // Progressive enemy stat scaling per level (after early game)
     HEALTH_PER_LEVEL: 0.12,      // +12% health per level after early game
     DAMAGE_PER_LEVEL: 0.08,      // +8% damage per level after early game
-    SPEED_PER_LEVEL: 0.03        // +3% speed per level after early game
+    SPEED_PER_LEVEL: 0.03,       // +3% speed per level after early game
+    MAX_PROGRESSIVE_DAMAGE_BONUS: 6  // cap so endless-mode damage scaling stays "hard but fair" instead of compounding unbounded
   };
 
   // Cached power calculations (invalidated when upgrades change)
@@ -639,7 +640,10 @@
     // Calculate progressive enemy stat bonuses (kicks in after early game)
     const levelsAfterEasy = Math.max(0, level - ADAPTIVE_CONSTANTS.EASY_LEVELS);
     const progressiveHealthBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.HEALTH_PER_LEVEL;
-    const progressiveDamageBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.DAMAGE_PER_LEVEL;
+    const progressiveDamageBonus = Math.min(
+      ADAPTIVE_CONSTANTS.MAX_PROGRESSIVE_DAMAGE_BONUS,
+      1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.DAMAGE_PER_LEVEL
+    );
     const progressiveSpeedBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.SPEED_PER_LEVEL;
     
     return {
@@ -1221,6 +1225,18 @@
   const _applyPerk = (perkId) => {
     const perk = PERK_CATALOG.find(p => p.id === perkId);
     if (!perk) return;
+
+    // Once every perk in the catalog is owned, _pickRandomPerks() falls back
+    // to offering already-owned cards so the picker never runs dry — but
+    // re-running perk.apply() would silently re-stack that perk's multiplier
+    // past its intended one-time value. Convert a repeat pick into a flat
+    // credit payout instead of a no-op so the card still feels worth taking.
+    if (activePerks.includes(perkId)) {
+      Save.addCredits(30);
+      addLogEntry(`PERK MAXED: ${perk.name} (+30 credits)`, '#a5b4fc');
+      return;
+    }
+
     activePerks.push(perkId);
     perk.apply(perkMultipliers);
 
@@ -2873,14 +2889,18 @@ PowerUps.reset();
         p.y += p.vy * step;
       }
       
+      if (p.maxLife === undefined) p.maxLife = p.life;
       p.life -= dt;
       if (p.life <= 0 || (p.type === 'ring' && p.r >= p.maxR)) {
         particles.splice(i, 1);
         continue;
       }
-      
-      // Phase A.4: Enhanced rendering based on type
-      const alpha = Math.max(0, p.life / 320);
+
+      // Phase A.4: Enhanced rendering based on type — normalize against each
+      // particle's own spawn lifespan (life values range 180-500 by kind),
+      // not a fixed divisor, so short-lived particles reach full opacity and
+      // long-lived ones don't clip alpha above 1.
+      const alpha = Math.max(0, p.life / (p.maxLife || 320));
       ctx.globalAlpha = alpha;
       
       if (p.type === 'ring') {
@@ -13489,18 +13509,6 @@ PowerUps.reset();
   // Daily missions still progress in the background. Full list lives in Hangar.
   // A brief toast fires when a mission completes — never a persistent HUD panel.
   let _missionPrevCompleted = new Set();
-
-  function getHudAccent() {
-    const THEME_COLORS = {
-      cyan:   '#38bdf8',
-      green:  '#4ade80',
-      red:    '#f87171',
-      purple: '#a855f7',
-      gold:   '#fbbf24',
-    };
-    const saved = localStorage.getItem('voidrift_hud_theme') || 'cyan';
-    return THEME_COLORS[saved] || '#38bdf8';
-  }
 
   function setMissionHudExpanded(_open) {
     // no-op: in-game mission panel removed

--- a/ios/VoidRift/WebContent/unified-social.js
+++ b/ios/VoidRift/WebContent/unified-social.js
@@ -124,9 +124,12 @@ const UnifiedSocial = {
     }
   },
 
-  // Report achievement to both systems
+  // Report achievement to Game Center. Local/web achievement tracking and
+  // toasts are owned exclusively by Auth.checkAchievements() (script.js) —
+  // this used to also write to an orphaned `void_rift_auth_profile_*` key
+  // and fire its own '.achievement-toast', which meant every unlock showed
+  // two stacked "Achievement Unlocked" toasts for the same milestone.
   async reportAchievement(achievementKey, percentComplete = 100) {
-    // Report to Game Center (iOS only)
     if (this.isGameCenterAuthenticated) {
       const gcID = this.achievementIDs[achievementKey];
       if (gcID) {
@@ -136,28 +139,6 @@ const UnifiedSocial = {
           // Silently ignore Game Center errors
         }
       }
-    }
-    
-    // Store locally for web
-    try {
-      const authKey = 'void_rift_auth';
-      const currentUser = JSON.parse(localStorage.getItem(authKey) || '{}').currentUser;
-      const profileKey = `${authKey}_profile_${currentUser || 'guest'}`;
-      const profile = JSON.parse(localStorage.getItem(profileKey) || '{}');
-      
-      if (!profile.unlockedAchievements) {
-        profile.unlockedAchievements = [];
-      }
-      
-      if (!profile.unlockedAchievements.includes(achievementKey)) {
-        profile.unlockedAchievements.push(achievementKey);
-        localStorage.setItem(profileKey, JSON.stringify(profile));
-        
-        // Show achievement notification
-        this.showAchievementNotification(achievementKey);
-      }
-    } catch (error) {
-      // Silently ignore local achievement errors
     }
   },
 
@@ -330,61 +311,6 @@ const UnifiedSocial = {
     } catch (err) {
       console.error('[UnifiedSocial] showProfile failed', err);
     }
-  },
-
-  // Show achievement notification
-  showAchievementNotification(achievementKey) {
-    const achievementNames = {
-      firstBlood: 'First Blood',
-      centurion: 'Centurion',
-      slayer: 'Slayer',
-      bossHunter: 'Boss Hunter',
-      survivor: 'Survivor',
-      veteran: 'Veteran',
-      champion: 'Champion',
-      flawless: 'Flawless Victory',
-      prestige1: 'Prestige I',
-      prestige5: 'Prestige V',
-      prestige10: 'Prestige X'
-    };
-    
-    const achievementIcons = {
-      firstBlood: '🎯',
-      centurion: '⚔️',
-      slayer: '💀',
-      bossHunter: '👹',
-      survivor: '🛡️',
-      veteran: '⭐',
-      champion: '🏆',
-      flawless: '✨',
-      prestige1: '🌟',
-      prestige5: '💫',
-      prestige10: '🔱'
-    };
-    
-    const name = achievementNames[achievementKey] || achievementKey;
-    const icon = achievementIcons[achievementKey] || '🏅';
-    
-    // Create toast notification
-    const toast = document.createElement('div');
-    toast.className = 'achievement-toast';
-    toast.innerHTML = `
-      <div class="achievement-toast-icon">${icon}</div>
-      <div class="achievement-toast-content">
-        <div class="achievement-toast-title">ACHIEVEMENT UNLOCKED!</div>
-        <div class="achievement-toast-name">${name}</div>
-      </div>
-    `;
-    
-    document.body.appendChild(toast);
-    setTimeout(() => toast.classList.add('show'), 100);
-    
-    setTimeout(() => {
-      toast.classList.remove('show');
-      setTimeout(() => {
-        if (toast.parentNode) toast.remove();
-      }, 300);
-    }, 4000);
   },
 
   // Handle game over with unified social features

--- a/script.js
+++ b/script.js
@@ -568,7 +568,8 @@
     // Progressive enemy stat scaling per level (after early game)
     HEALTH_PER_LEVEL: 0.12,      // +12% health per level after early game
     DAMAGE_PER_LEVEL: 0.08,      // +8% damage per level after early game
-    SPEED_PER_LEVEL: 0.03        // +3% speed per level after early game
+    SPEED_PER_LEVEL: 0.03,       // +3% speed per level after early game
+    MAX_PROGRESSIVE_DAMAGE_BONUS: 6  // cap so endless-mode damage scaling stays "hard but fair" instead of compounding unbounded
   };
 
   // Cached power calculations (invalidated when upgrades change)
@@ -639,7 +640,10 @@
     // Calculate progressive enemy stat bonuses (kicks in after early game)
     const levelsAfterEasy = Math.max(0, level - ADAPTIVE_CONSTANTS.EASY_LEVELS);
     const progressiveHealthBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.HEALTH_PER_LEVEL;
-    const progressiveDamageBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.DAMAGE_PER_LEVEL;
+    const progressiveDamageBonus = Math.min(
+      ADAPTIVE_CONSTANTS.MAX_PROGRESSIVE_DAMAGE_BONUS,
+      1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.DAMAGE_PER_LEVEL
+    );
     const progressiveSpeedBonus = 1 + levelsAfterEasy * ADAPTIVE_CONSTANTS.SPEED_PER_LEVEL;
     
     return {
@@ -1221,6 +1225,18 @@
   const _applyPerk = (perkId) => {
     const perk = PERK_CATALOG.find(p => p.id === perkId);
     if (!perk) return;
+
+    // Once every perk in the catalog is owned, _pickRandomPerks() falls back
+    // to offering already-owned cards so the picker never runs dry — but
+    // re-running perk.apply() would silently re-stack that perk's multiplier
+    // past its intended one-time value. Convert a repeat pick into a flat
+    // credit payout instead of a no-op so the card still feels worth taking.
+    if (activePerks.includes(perkId)) {
+      Save.addCredits(30);
+      addLogEntry(`PERK MAXED: ${perk.name} (+30 credits)`, '#a5b4fc');
+      return;
+    }
+
     activePerks.push(perkId);
     perk.apply(perkMultipliers);
 
@@ -2873,14 +2889,18 @@ PowerUps.reset();
         p.y += p.vy * step;
       }
       
+      if (p.maxLife === undefined) p.maxLife = p.life;
       p.life -= dt;
       if (p.life <= 0 || (p.type === 'ring' && p.r >= p.maxR)) {
         particles.splice(i, 1);
         continue;
       }
-      
-      // Phase A.4: Enhanced rendering based on type
-      const alpha = Math.max(0, p.life / 320);
+
+      // Phase A.4: Enhanced rendering based on type — normalize against each
+      // particle's own spawn lifespan (life values range 180-500 by kind),
+      // not a fixed divisor, so short-lived particles reach full opacity and
+      // long-lived ones don't clip alpha above 1.
+      const alpha = Math.max(0, p.life / (p.maxLife || 320));
       ctx.globalAlpha = alpha;
       
       if (p.type === 'ring') {
@@ -13489,18 +13509,6 @@ PowerUps.reset();
   // Daily missions still progress in the background. Full list lives in Hangar.
   // A brief toast fires when a mission completes — never a persistent HUD panel.
   let _missionPrevCompleted = new Set();
-
-  function getHudAccent() {
-    const THEME_COLORS = {
-      cyan:   '#38bdf8',
-      green:  '#4ade80',
-      red:    '#f87171',
-      purple: '#a855f7',
-      gold:   '#fbbf24',
-    };
-    const saved = localStorage.getItem('voidrift_hud_theme') || 'cyan';
-    return THEME_COLORS[saved] || '#38bdf8';
-  }
 
   function setMissionHudExpanded(_open) {
     // no-op: in-game mission panel removed

--- a/unified-social.js
+++ b/unified-social.js
@@ -124,9 +124,12 @@ const UnifiedSocial = {
     }
   },
 
-  // Report achievement to both systems
+  // Report achievement to Game Center. Local/web achievement tracking and
+  // toasts are owned exclusively by Auth.checkAchievements() (script.js) —
+  // this used to also write to an orphaned `void_rift_auth_profile_*` key
+  // and fire its own '.achievement-toast', which meant every unlock showed
+  // two stacked "Achievement Unlocked" toasts for the same milestone.
   async reportAchievement(achievementKey, percentComplete = 100) {
-    // Report to Game Center (iOS only)
     if (this.isGameCenterAuthenticated) {
       const gcID = this.achievementIDs[achievementKey];
       if (gcID) {
@@ -136,28 +139,6 @@ const UnifiedSocial = {
           // Silently ignore Game Center errors
         }
       }
-    }
-    
-    // Store locally for web
-    try {
-      const authKey = 'void_rift_auth';
-      const currentUser = JSON.parse(localStorage.getItem(authKey) || '{}').currentUser;
-      const profileKey = `${authKey}_profile_${currentUser || 'guest'}`;
-      const profile = JSON.parse(localStorage.getItem(profileKey) || '{}');
-      
-      if (!profile.unlockedAchievements) {
-        profile.unlockedAchievements = [];
-      }
-      
-      if (!profile.unlockedAchievements.includes(achievementKey)) {
-        profile.unlockedAchievements.push(achievementKey);
-        localStorage.setItem(profileKey, JSON.stringify(profile));
-        
-        // Show achievement notification
-        this.showAchievementNotification(achievementKey);
-      }
-    } catch (error) {
-      // Silently ignore local achievement errors
     }
   },
 
@@ -330,61 +311,6 @@ const UnifiedSocial = {
     } catch (err) {
       console.error('[UnifiedSocial] showProfile failed', err);
     }
-  },
-
-  // Show achievement notification
-  showAchievementNotification(achievementKey) {
-    const achievementNames = {
-      firstBlood: 'First Blood',
-      centurion: 'Centurion',
-      slayer: 'Slayer',
-      bossHunter: 'Boss Hunter',
-      survivor: 'Survivor',
-      veteran: 'Veteran',
-      champion: 'Champion',
-      flawless: 'Flawless Victory',
-      prestige1: 'Prestige I',
-      prestige5: 'Prestige V',
-      prestige10: 'Prestige X'
-    };
-    
-    const achievementIcons = {
-      firstBlood: '🎯',
-      centurion: '⚔️',
-      slayer: '💀',
-      bossHunter: '👹',
-      survivor: '🛡️',
-      veteran: '⭐',
-      champion: '🏆',
-      flawless: '✨',
-      prestige1: '🌟',
-      prestige5: '💫',
-      prestige10: '🔱'
-    };
-    
-    const name = achievementNames[achievementKey] || achievementKey;
-    const icon = achievementIcons[achievementKey] || '🏅';
-    
-    // Create toast notification
-    const toast = document.createElement('div');
-    toast.className = 'achievement-toast';
-    toast.innerHTML = `
-      <div class="achievement-toast-icon">${icon}</div>
-      <div class="achievement-toast-content">
-        <div class="achievement-toast-title">ACHIEVEMENT UNLOCKED!</div>
-        <div class="achievement-toast-name">${name}</div>
-      </div>
-    `;
-    
-    document.body.appendChild(toast);
-    setTimeout(() => toast.classList.add('show'), 100);
-    
-    setTimeout(() => {
-      toast.classList.remove('show');
-      setTimeout(() => {
-        if (toast.parentNode) toast.remove();
-      }, 300);
-    }, 4000);
   },
 
   // Handle game over with unified social features


### PR DESCRIPTION
## Summary

Five bugs found and fixed continuing the recurring daily improvement loop (following #132-#139, #141-#143). No persisted "5 tasks" list exists anywhere retrievable (checked cron jobs, repo files, GitHub issues/PRs) — consistent with what #143 already found — so this round cross-checked `WEEKLY_ROADMAP.md` (#140) Day 2-7 items and the code touched by the still-open, unmerged daily-loop PRs (#141, #142, #143) to find genuine gaps that aren't already fixed or in flight elsewhere.

- **fix: perk double-dip once all 13 perks are owned.** `_pickRandomPerks()` (`script.js`) falls back to the full perk catalog — including already-owned perks — once `activePerks` covers everything, but `_applyPerk()` never checked for a repeat before calling `perk.apply()`. An "already owned" perk could silently re-stack its multiplier past its intended one-time value in long runs. A repeat pick now grants a flat credit payout instead of re-stacking, so the card still feels worth taking.
- **fix: duplicate "Achievement Unlocked" toasts on every game-over.** `UnifiedSocial.reportAchievement()` (`unified-social.js`) tracked its own achievement list in an orphaned `void_rift_auth_profile_*` localStorage key and fired its own `.achievement-toast`, running in parallel with `Auth.checkAchievements()` (`script.js`), which is the real source of truth for local/web achievements and toasts. Trimmed `reportAchievement` to only report to Game Center and removed the now-dead local toast helper.
- **fix: uncapped progressive enemy-damage scaling.** `progressiveDamageBonus` in `getAdaptiveScaling()` (`script.js`) grows linearly forever past wave ~3 with no ceiling, compounding into the already-capped adaptive damage factor and producing an effectively unwinnable damage wall in long/endless runs. Added `MAX_PROGRESSIVE_DAMAGE_BONUS` and clamped it, consistent with how every other adaptive-scaling factor in the same function is already capped.
- **fix: particle fade-alpha wrong divisor.** The particle renderer used a hardcoded `p.life / 320` divisor, but particle lifespans range 180-500ms depending on effect type — short-lived particles never reached full opacity, and long-lived ones produced an out-of-range `ctx.globalAlpha` (silently ignored by the Canvas spec, leaving stale alpha from the previous draw). Now normalizes against each particle's own captured `maxLife`.
- **chore: removed the inert Hangar "HUD Theme" swatch picker.** Its only reader, `getHudAccent()`, was never called anywhere — and the in-game mission HUD it was meant to color (per its own hint text, "Applies to mission HUD and status overlays") was already permanently hidden by an earlier daily-loop change, so there was nothing left for the setting to visibly affect. Removed the settings UI, its event wiring, and the dead reader rather than leaving a control that visibly does nothing.

`script.js`, `hangar-ui.js`, and `unified-social.js` synced to `ios/VoidRift/WebContent/` per the existing sync convention (verified byte-identical with `diff`).

## Test plan

- [x] `node --check` on all three modified files
- [x] `npx jest` — 175/175 tests pass (1 pre-existing unrelated failure: `leaderboard-api.test.js` needs `@vercel/kv`, not installed in this sandbox, fails identically on `main`)
- [x] `npx eslint script.js hangar-ui.js unified-social.js` — same 33 errors before/after (verified via `git stash` diff), 1 fewer warning (dead code removed), no new issues introduced
- [ ] Manual playtest of a long/endless run to confirm the damage-scaling cap and post-full-perk-catalog credit payout feel right in practice (not exercised beyond code review + automated checks)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKmfWjG62fwtozc4PqRzTd)_