### PR TITLE
Daily improvement loop: colorblind assist, reduced-motion, boss AI variety, prestige payoff, streak reward

### DIFF
--- a/daily-challenge.js
+++ b/daily-challenge.js
@@ -106,3 +106,22 @@ export function getTotalDailyChallengesCompleted() {
   const stored = loadDailyChallenge();
   return Object.keys(stored).length;
 }
+
+const STREAK_REWARD_KEY = 'voidrift_daily_streak_reward_claimed';
+export const STREAK_REWARD_INTERVAL = 3;
+export const STREAK_REWARD_CREDITS = 150;
+
+/**
+ * Grants a bonus-credit payout every STREAK_REWARD_INTERVAL-day streak
+ * (e.g. day 3, 6, 9, ...). Idempotent per calendar day — replaying today's
+ * challenge again won't re-grant the same milestone's reward.
+ * Returns the credit amount to award, or 0 if nothing is due.
+ */
+export function claimStreakReward() {
+  const streak = getDailyStreak();
+  if (streak <= 0 || streak % STREAK_REWARD_INTERVAL !== 0) return 0;
+  const today = todayStr();
+  if (localStorage.getItem(STREAK_REWARD_KEY) === today) return 0;
+  localStorage.setItem(STREAK_REWARD_KEY, today);
+  return STREAK_REWARD_CREDITS;
+}

--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -1241,6 +1241,8 @@ const HANGAR_UI_CSS = `
   .hangar-mute-btn { padding: 8px 18px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.15); background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.7); font-size: 13px; cursor: pointer; transition: background 0.2s; }
   .hangar-mute-btn:hover { background: rgba(255,255,255,0.12); }
   .hangar-mute-btn.muted { border-color: #ef4444; color: #ef4444; }
+  .hangar-select { flex: 1; padding: 7px 10px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.15); background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.85); font-size: 13px; cursor: pointer; }
+  .hangar-select:focus { outline: 1px solid rgba(74,222,128,0.5); }
 
   /* ── Remove Ads IAP section ──────────────────────────────────── */
   .hangar-iap-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
@@ -2161,6 +2163,18 @@ function renderSettingsView() {
           </label>
         </div>
         <div class="hangar-theme-hint">Boosts contrast and saturation to make enemies, bullets, and pickups easier to distinguish.</div>
+        <div class="hangar-settings-row">
+          <span>Colorblind Mode</span>
+          <select id="settings-colorblind-mode" class="hangar-select">
+            ${[
+              { id: 'off', label: 'Off' },
+              { id: 'deuteranopia', label: 'Deuteranopia' },
+              { id: 'protanopia', label: 'Protanopia' },
+              { id: 'tritanopia', label: 'Tritanopia' },
+            ].map(o => `<option value="${o.id}"${(localStorage.getItem('voidrift_colorblind_mode') || 'off') === o.id ? ' selected' : ''}>${o.label}</option>`).join('')}
+          </select>
+        </div>
+        <div class="hangar-theme-hint">Shifts red/green enemy and pickup tints toward blue/orange for red-green color-vision deficiency.</div>
       </div>
     </div>
   `;
@@ -2269,6 +2283,15 @@ function renderSettingsView() {
   if (highContrastToggle) {
     highContrastToggle.addEventListener('change', () => {
       localStorage.setItem('voidrift_high_contrast', highContrastToggle.checked ? '1' : '0');
+      if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
+    });
+  }
+
+  // Wire up Colorblind Mode select
+  const colorblindSelect = document.getElementById('settings-colorblind-mode');
+  if (colorblindSelect) {
+    colorblindSelect.addEventListener('change', () => {
+      localStorage.setItem('voidrift_colorblind_mode', colorblindSelect.value);
       if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
     });
   }
@@ -3240,16 +3263,18 @@ function renderStatsView() {
     const prestigeBox = document.createElement('div');
     prestigeBox.style.cssText = 'margin-top:16px; background:rgba(192,132,252,0.06); border:1px solid rgba(192,132,252,0.25); border-radius:10px; padding:14px 16px;';
 
+    const bonusPct = Math.round(((typeof auth.getPrestigeBonusMultiplier === 'function' ? auth.getPrestigeBonusMultiplier() : 1) - 1) * 100);
     if (auth.canPrestige()) {
+      const nextBonusPct = Math.round((((profile.prestige || 0) + 1) * 1.5));
       prestigeBox.innerHTML = `
         <div style="font-size:11px;color:#c084fc;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:8px;">&#11088; Prestige Available</div>
-        <div style="font-size:12px;color:rgba(255,255,255,0.6);margin-bottom:10px;">Reset your Pilot Level to 1 for a permanent title and reward. Credits and upgrades are kept.</div>
+        <div style="font-size:12px;color:rgba(255,255,255,0.6);margin-bottom:10px;">Reset your Pilot Level to 1 for a permanent title, reward, and a lasting +${nextBonusPct}% credits/XP bonus. Credits and upgrades are kept.</div>
         <button id="hangar-prestige-btn" style="padding:8px 16px; border-radius:8px; border:1px solid rgba(192,132,252,0.4); background:rgba(192,132,252,0.15); color:#e9d5ff; font-weight:700; cursor:pointer;">Prestige Now (${(profile.prestige || 0) + 1}/10)</button>
       `;
     } else {
       const current = profile.prestige || 0;
       prestigeBox.innerHTML = `
-        <div style="font-size:11px;color:rgba(255,255,255,0.3);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px;">&#11088; Prestige ${current}/10${profile.title ? ` — ${profile.title}` : ''}</div>
+        <div style="font-size:11px;color:rgba(255,255,255,0.3);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px;">&#11088; Prestige ${current}/10${profile.title ? ` — ${profile.title}` : ''}${current > 0 ? ` (+${bonusPct}% credits/XP)` : ''}</div>
         <div style="font-size:11px;color:rgba(255,255,255,0.28);">Reach Pilot Level 50 to prestige again.</div>
       `;
     }

--- a/index.html
+++ b/index.html
@@ -163,7 +163,34 @@
   <!-- GAME CONTAINER -->
   <div id="gameContainer">
     <canvas id="gameCanvas"></canvas>
-    
+    <!-- Colorblind-assist filters: shift red/green apart toward blue/orange so enemy tints,
+         bullets, and pickups stay distinguishable for red-green color-vision deficiency. -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <filter id="cbFilterDeuteranopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            0.6  0.4   0    0 0
+            0.15 0.7   0.15 0 0
+           -0.15 0.15  1.3  0 0
+            0    0     0    1 0"/>
+        </filter>
+        <filter id="cbFilterProtanopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            0.5  0.5   0    0 0
+            0.15 0.75  0.1  0 0
+           -0.15 0.15  1.3  0 0
+            0    0     0    1 0"/>
+        </filter>
+        <filter id="cbFilterTritanopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            1.2 -0.15  0    0 0
+            0    0.9   0.1  0 0
+            0    0.35  0.9  0 0
+            0    0     0    1 0"/>
+        </filter>
+      </defs>
+    </svg>
+
     <!-- HUD -->
     <div id="uiPanel">
       <div class="ui-stat-row"><span class="ui-text-label">Score:</span><span id="scoreValue" class="ui-text-value">0</span></div>

--- a/ios/VoidRift/WebContent/daily-challenge.js
+++ b/ios/VoidRift/WebContent/daily-challenge.js
@@ -106,3 +106,22 @@ export function getTotalDailyChallengesCompleted() {
   const stored = loadDailyChallenge();
   return Object.keys(stored).length;
 }
+
+const STREAK_REWARD_KEY = 'voidrift_daily_streak_reward_claimed';
+export const STREAK_REWARD_INTERVAL = 3;
+export const STREAK_REWARD_CREDITS = 150;
+
+/**
+ * Grants a bonus-credit payout every STREAK_REWARD_INTERVAL-day streak
+ * (e.g. day 3, 6, 9, ...). Idempotent per calendar day — replaying today's
+ * challenge again won't re-grant the same milestone's reward.
+ * Returns the credit amount to award, or 0 if nothing is due.
+ */
+export function claimStreakReward() {
+  const streak = getDailyStreak();
+  if (streak <= 0 || streak % STREAK_REWARD_INTERVAL !== 0) return 0;
+  const today = todayStr();
+  if (localStorage.getItem(STREAK_REWARD_KEY) === today) return 0;
+  localStorage.setItem(STREAK_REWARD_KEY, today);
+  return STREAK_REWARD_CREDITS;
+}

--- a/ios/VoidRift/WebContent/hangar-ui.js
+++ b/ios/VoidRift/WebContent/hangar-ui.js
@@ -1241,6 +1241,8 @@ const HANGAR_UI_CSS = `
   .hangar-mute-btn { padding: 8px 18px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.15); background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.7); font-size: 13px; cursor: pointer; transition: background 0.2s; }
   .hangar-mute-btn:hover { background: rgba(255,255,255,0.12); }
   .hangar-mute-btn.muted { border-color: #ef4444; color: #ef4444; }
+  .hangar-select { flex: 1; padding: 7px 10px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.15); background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.85); font-size: 13px; cursor: pointer; }
+  .hangar-select:focus { outline: 1px solid rgba(74,222,128,0.5); }
 
   /* ── Remove Ads IAP section ──────────────────────────────────── */
   .hangar-iap-section { margin-top: 8px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.08); }
@@ -2161,6 +2163,18 @@ function renderSettingsView() {
           </label>
         </div>
         <div class="hangar-theme-hint">Boosts contrast and saturation to make enemies, bullets, and pickups easier to distinguish.</div>
+        <div class="hangar-settings-row">
+          <span>Colorblind Mode</span>
+          <select id="settings-colorblind-mode" class="hangar-select">
+            ${[
+              { id: 'off', label: 'Off' },
+              { id: 'deuteranopia', label: 'Deuteranopia' },
+              { id: 'protanopia', label: 'Protanopia' },
+              { id: 'tritanopia', label: 'Tritanopia' },
+            ].map(o => `<option value="${o.id}"${(localStorage.getItem('voidrift_colorblind_mode') || 'off') === o.id ? ' selected' : ''}>${o.label}</option>`).join('')}
+          </select>
+        </div>
+        <div class="hangar-theme-hint">Shifts red/green enemy and pickup tints toward blue/orange for red-green color-vision deficiency.</div>
       </div>
     </div>
   `;
@@ -2269,6 +2283,15 @@ function renderSettingsView() {
   if (highContrastToggle) {
     highContrastToggle.addEventListener('change', () => {
       localStorage.setItem('voidrift_high_contrast', highContrastToggle.checked ? '1' : '0');
+      if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
+    });
+  }
+
+  // Wire up Colorblind Mode select
+  const colorblindSelect = document.getElementById('settings-colorblind-mode');
+  if (colorblindSelect) {
+    colorblindSelect.addEventListener('change', () => {
+      localStorage.setItem('voidrift_colorblind_mode', colorblindSelect.value);
       if (typeof window.applyHighContrast === 'function') window.applyHighContrast();
     });
   }
@@ -3240,16 +3263,18 @@ function renderStatsView() {
     const prestigeBox = document.createElement('div');
     prestigeBox.style.cssText = 'margin-top:16px; background:rgba(192,132,252,0.06); border:1px solid rgba(192,132,252,0.25); border-radius:10px; padding:14px 16px;';
 
+    const bonusPct = Math.round(((typeof auth.getPrestigeBonusMultiplier === 'function' ? auth.getPrestigeBonusMultiplier() : 1) - 1) * 100);
     if (auth.canPrestige()) {
+      const nextBonusPct = Math.round((((profile.prestige || 0) + 1) * 1.5));
       prestigeBox.innerHTML = `
         <div style="font-size:11px;color:#c084fc;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:8px;">&#11088; Prestige Available</div>
-        <div style="font-size:12px;color:rgba(255,255,255,0.6);margin-bottom:10px;">Reset your Pilot Level to 1 for a permanent title and reward. Credits and upgrades are kept.</div>
+        <div style="font-size:12px;color:rgba(255,255,255,0.6);margin-bottom:10px;">Reset your Pilot Level to 1 for a permanent title, reward, and a lasting +${nextBonusPct}% credits/XP bonus. Credits and upgrades are kept.</div>
         <button id="hangar-prestige-btn" style="padding:8px 16px; border-radius:8px; border:1px solid rgba(192,132,252,0.4); background:rgba(192,132,252,0.15); color:#e9d5ff; font-weight:700; cursor:pointer;">Prestige Now (${(profile.prestige || 0) + 1}/10)</button>
       `;
     } else {
       const current = profile.prestige || 0;
       prestigeBox.innerHTML = `
-        <div style="font-size:11px;color:rgba(255,255,255,0.3);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px;">&#11088; Prestige ${current}/10${profile.title ? ` — ${profile.title}` : ''}</div>
+        <div style="font-size:11px;color:rgba(255,255,255,0.3);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px;">&#11088; Prestige ${current}/10${profile.title ? ` — ${profile.title}` : ''}${current > 0 ? ` (+${bonusPct}% credits/XP)` : ''}</div>
         <div style="font-size:11px;color:rgba(255,255,255,0.28);">Reach Pilot Level 50 to prestige again.</div>
       `;
     }

--- a/ios/VoidRift/WebContent/index.html
+++ b/ios/VoidRift/WebContent/index.html
@@ -163,7 +163,34 @@
   <!-- GAME CONTAINER -->
   <div id="gameContainer">
     <canvas id="gameCanvas"></canvas>
-    
+    <!-- Colorblind-assist filters: shift red/green apart toward blue/orange so enemy tints,
+         bullets, and pickups stay distinguishable for red-green color-vision deficiency. -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <filter id="cbFilterDeuteranopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            0.6  0.4   0    0 0
+            0.15 0.7   0.15 0 0
+           -0.15 0.15  1.3  0 0
+            0    0     0    1 0"/>
+        </filter>
+        <filter id="cbFilterProtanopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            0.5  0.5   0    0 0
+            0.15 0.75  0.1  0 0
+           -0.15 0.15  1.3  0 0
+            0    0     0    1 0"/>
+        </filter>
+        <filter id="cbFilterTritanopia" color-interpolation-filters="sRGB">
+          <feColorMatrix type="matrix" values="
+            1.2 -0.15  0    0 0
+            0    0.9   0.1  0 0
+            0    0.35  0.9  0 0
+            0    0     0    1 0"/>
+        </filter>
+      </defs>
+    </svg>
+
     <!-- HUD -->
     <div id="uiPanel">
       <div class="ui-stat-row"><span class="ui-text-label">Score:</span><span id="scoreValue" class="ui-text-value">0</span></div>

--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -1688,6 +1688,9 @@
       }
     },
     addCredits(amount) {
+      if (amount > 0 && typeof Auth !== 'undefined' && Auth.getPrestigeBonusMultiplier) {
+        amount = Math.floor(amount * Auth.getPrestigeBonusMultiplier());
+      }
       this.data.credits = Math.max(0, Math.floor(this.data.credits + amount));
       syncCredits();
       this.save();
@@ -1972,7 +1975,14 @@
     canPrestige() {
       return Save.data.pilotLevel >= PRESTIGE_LEVELS_PER_TIER && this.playerProfile.prestige < MAX_PRESTIGE;
     },
-    
+
+    // Small permanent per-tier payoff for prestiging: +1.5% credits/XP per tier
+    // (e.g. Prestige 5 = +7.5%), so resetting pilot level keeps paying off afterward
+    // instead of only granting a one-time cosmetic unlock.
+    getPrestigeBonusMultiplier() {
+      return 1 + (this.playerProfile.prestige || 0) * 0.015;
+    },
+
     doPrestige() {
       if (!this.canPrestige()) return false;
       
@@ -2493,6 +2503,10 @@ PowerUps.reset();
     if (xpBoostMultiplier > 1) {
       amount = Math.floor(amount * xpBoostMultiplier);
     }
+    // Small permanent per-prestige-tier XP bonus
+    if (typeof Auth !== 'undefined' && Auth.getPrestigeBonusMultiplier) {
+      amount = Math.floor(amount * Auth.getPrestigeBonusMultiplier());
+    }
 
     xpEarnedThisRun += amount;
     pilotXP += amount;
@@ -2539,7 +2553,15 @@ PowerUps.reset();
   };
 
   const getShakeIntensity = () => {
-    const stored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+    const raw = localStorage.getItem('voidrift_screen_shake');
+    // No explicit slider preference yet — default to the OS reduced-motion setting
+    // instead of always assuming full-intensity shake.
+    if (raw === null) {
+      const prefersReduced = typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      return prefersReduced ? 0 : 1;
+    }
+    const stored = parseInt(raw, 10);
     return (Number.isFinite(stored) ? stored : 100) / 100;
   };
 
@@ -6911,8 +6933,12 @@ PowerUps.reset();
     performSpecialAttack(now) {
       if (!player) return;
       this.lastSpecialAttack = now;
+      // The two generic (non-named) boss shapes get their own attack identity
+      // instead of sharing one interchangeable radial/charge/summon rotation.
+      if (this.kind === 'heavy') { this.performHeavyBossAttack(); return; }
+      if (this.kind === 'chaser') { this.performChaserBossAttack(); return; }
       this.attackPhase = (this.attackPhase + 1) % 3;
-      
+
       switch (this.attackPhase) {
         case 0: // Radial burst - fires in all directions
           for (let i = 0; i < 12; i++) {
@@ -6951,7 +6977,73 @@ PowerUps.reset();
           break;
       }
     }
-    
+
+    // Heavy-shape boss: slow, armor-plated juggernaut. Alternates a wide artillery
+    // spread with a ground-slam shockwave that punishes players who stay close.
+    performHeavyBossAttack() {
+      if (!player) return;
+      this.attackPhase = (this.attackPhase + 1) % 2;
+
+      if (this.attackPhase === 0) {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const baseAngle = Math.atan2(dy, dx);
+        const damage = this.baseDamage * 0.9;
+        const spread = 5;
+        for (let i = 0; i < spread; i++) {
+          const ang = baseAngle - 0.3 + (i / (spread - 1)) * 0.6;
+          const vel = { x: Math.cos(ang), y: Math.sin(ang) };
+          bullets.push(new Bullet(this.x, this.y, vel, damage, '#f97316', BASE.BULLET_SPEED * 0.55, BASE.BULLET_SIZE * 1.6, 0, true));
+        }
+        addParticles('muzzle', this.x, this.y, baseAngle, 10);
+        shakeScreen(6, 200);
+        addLogEntry('⚠️ Heavy artillery barrage!', '#f97316');
+      } else {
+        const slamRadius = this.size * 3.2;
+        const dist = Math.hypot(player.x - this.x, player.y - this.y);
+        if (dist < slamRadius) {
+          player.takeDamage(this.baseDamage * 1.8, this);
+        }
+        addParticles('ring', this.x, this.y, 0, 24, '#ea580c');
+        shakeScreen(11, 350);
+        addLogEntry('⚠️ Boss ground-slam shockwave!', '#ea580c');
+      }
+    }
+
+    // Chaser-shape boss: fast, relentless void reaper. Blinks toward the player
+    // then unleashes a converging burst — punishes standing still, not proximity.
+    performChaserBossAttack() {
+      if (!player) return;
+      this.attackPhase = (this.attackPhase + 1) % 2;
+
+      if (this.attackPhase === 0) {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const dist = Math.hypot(dx, dy) || 1;
+        const blinkDist = Math.min(dist - this.size * 1.5, 260);
+        if (blinkDist > 0) {
+          this.x += (dx / dist) * blinkDist;
+          this.y += (dy / dist) * blinkDist;
+        }
+        addParticles('sparks', this.x, this.y, 0, 18, '#e879f9');
+        shakeScreen(7, 180);
+        addLogEntry('⚠️ Boss blinks in close!', '#e879f9');
+      } else {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const baseAngle = Math.atan2(dy, dx);
+        const damage = this.baseDamage * 0.6;
+        const converge = 8;
+        for (let i = 0; i < converge; i++) {
+          const ang = (i / converge) * Math.PI * 2;
+          const vel = { x: Math.cos(ang), y: Math.sin(ang) };
+          bullets.push(new Bullet(this.x, this.y, vel, damage, '#a78bfa', BASE.BULLET_SPEED * 0.85, BASE.BULLET_SIZE * 1.1, 0, true));
+        }
+        addParticles('nova', this.x, this.y, 0, 16);
+        addLogEntry('⚠️ Boss unleashes a converging burst!', '#a78bfa');
+      }
+    }
+
     leviathanFirePhase(phase) {
       if (!player) return;
       const dx = player.x - this.x;
@@ -13424,7 +13516,7 @@ PowerUps.reset();
 
     // Save daily challenge best and restore Math.random
     if (window.DAILY_CHALLENGE_ACTIVE) {
-      import('./daily-challenge.js').then(({ saveDailyBest, getTodayBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted }) => {
+      import('./daily-challenge.js').then(({ saveDailyBest, getTodayBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted, claimStreakReward }) => {
         // saveDailyBest() only overwrites the stored best when finalScore is
         // actually higher — but its return value was previously discarded,
         // so the display below unconditionally showed *this run's* score
@@ -13434,15 +13526,27 @@ PowerUps.reset();
         const bestEl = document.getElementById('dailyBestDisplay');
         if (bestEl) bestEl.textContent = `Best: ${getTodayBest().toLocaleString()}`;
 
+        const streak = getDailyStreak();
+
         // Update achievement stats for daily challenge completion
         try {
           const completedCount = getTotalDailyChallengesCompleted();
-          const streak = getDailyStreak();
           if (typeof window.updateAchievementStats === 'function') {
             window.updateAchievementStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
           }
         } catch (e) {
           console.warn('[DailyChallenge] Achievement stats error:', e);
+        }
+
+        // Streak reward payoff — the streak was tracked but had zero payoff before
+        try {
+          const streakBonus = claimStreakReward();
+          if (streakBonus > 0) {
+            Save.addCredits(streakBonus);
+            showStreakBonusToast(streak, streakBonus);
+          }
+        } catch (e) {
+          console.warn('[DailyChallenge] Streak reward error:', e);
         }
       }).catch(err => console.warn('[DailyChallenge] Save failed:', err));
     }
@@ -13480,10 +13584,21 @@ PowerUps.reset();
   };
 
   // ── Accessibility ────────────────────────────────────────────────────────
+  const COLORBLIND_FILTER_IDS = {
+    deuteranopia: 'cbFilterDeuteranopia',
+    protanopia: 'cbFilterProtanopia',
+    tritanopia: 'cbFilterTritanopia',
+  };
+
   function applyHighContrast() {
     const enabled = localStorage.getItem('voidrift_high_contrast') === '1';
+    const cbMode = localStorage.getItem('voidrift_colorblind_mode') || 'off';
     if (dom.canvas) {
-      dom.canvas.style.filter = enabled ? 'contrast(1.35) saturate(1.5) brightness(1.05)' : '';
+      const filters = [];
+      const cbId = COLORBLIND_FILTER_IDS[cbMode];
+      if (cbId) filters.push(`url(#${cbId})`);
+      if (enabled) filters.push('contrast(1.35) saturate(1.5) brightness(1.05)');
+      dom.canvas.style.filter = filters.join(' ');
     }
   }
   window.applyHighContrast = applyHighContrast;
@@ -13544,6 +13659,36 @@ PowerUps.reset();
       setTimeout(() => { el.style.display = 'none'; }, 320);
       _missionToastTimeout = null;
     }, 2500);
+  }
+
+  let _streakToastTimeout = null;
+  function showStreakBonusToast(streak, credits) {
+    const el = document.getElementById('mission-complete-toast');
+    if (!el) {
+      try {
+        if (typeof addLogEntry === 'function') {
+          addLogEntry(`🔥 ${streak}-Day Streak: +${credits} credits!`, '#fbbf24');
+        }
+      } catch (_) {}
+      return;
+    }
+    // Share the mission-complete toast element/timers so a reward that fires
+    // right at game-over doesn't fight a still-visible mission toast.
+    if (_missionToastTimeout !== null) { clearTimeout(_missionToastTimeout); _missionToastTimeout = null; }
+    if (_streakToastTimeout !== null) { clearTimeout(_streakToastTimeout); _streakToastTimeout = null; }
+
+    el.innerHTML =
+      `<div class="mission-complete-toast__header">🔥 ${streak}-Day Streak</div>` +
+      `<div class="mission-complete-toast__name">+${credits} bonus credits</div>`;
+    el.style.display = 'block';
+    void el.offsetWidth;
+    el.classList.add('mission-complete-toast--visible');
+
+    _streakToastTimeout = setTimeout(() => {
+      el.classList.remove('mission-complete-toast--visible');
+      setTimeout(() => { el.style.display = 'none'; }, 320);
+      _streakToastTimeout = null;
+    }, 3000);
   }
 
   function updateMissionHUD() {

--- a/ios/VoidRift/WebContent/style.css
+++ b/ios/VoidRift/WebContent/style.css
@@ -5099,3 +5099,16 @@ label,
   color: #ffffff;
   letter-spacing: 0.05em;
 }
+
+/* ── Reduced motion ────────────────────────────────────────────────────────
+   Respect the OS-level accessibility setting: collapse looping/pulsing
+   animations (HUD glows, wave-card pulses, title/button pulses, toasts)
+   and instant-finish transitions, without removing the underlying layout. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1688,6 +1688,9 @@
       }
     },
     addCredits(amount) {
+      if (amount > 0 && typeof Auth !== 'undefined' && Auth.getPrestigeBonusMultiplier) {
+        amount = Math.floor(amount * Auth.getPrestigeBonusMultiplier());
+      }
       this.data.credits = Math.max(0, Math.floor(this.data.credits + amount));
       syncCredits();
       this.save();
@@ -1972,7 +1975,14 @@
     canPrestige() {
       return Save.data.pilotLevel >= PRESTIGE_LEVELS_PER_TIER && this.playerProfile.prestige < MAX_PRESTIGE;
     },
-    
+
+    // Small permanent per-tier payoff for prestiging: +1.5% credits/XP per tier
+    // (e.g. Prestige 5 = +7.5%), so resetting pilot level keeps paying off afterward
+    // instead of only granting a one-time cosmetic unlock.
+    getPrestigeBonusMultiplier() {
+      return 1 + (this.playerProfile.prestige || 0) * 0.015;
+    },
+
     doPrestige() {
       if (!this.canPrestige()) return false;
       
@@ -2493,6 +2503,10 @@ PowerUps.reset();
     if (xpBoostMultiplier > 1) {
       amount = Math.floor(amount * xpBoostMultiplier);
     }
+    // Small permanent per-prestige-tier XP bonus
+    if (typeof Auth !== 'undefined' && Auth.getPrestigeBonusMultiplier) {
+      amount = Math.floor(amount * Auth.getPrestigeBonusMultiplier());
+    }
 
     xpEarnedThisRun += amount;
     pilotXP += amount;
@@ -2539,7 +2553,15 @@ PowerUps.reset();
   };
 
   const getShakeIntensity = () => {
-    const stored = parseInt(localStorage.getItem('voidrift_screen_shake'), 10);
+    const raw = localStorage.getItem('voidrift_screen_shake');
+    // No explicit slider preference yet — default to the OS reduced-motion setting
+    // instead of always assuming full-intensity shake.
+    if (raw === null) {
+      const prefersReduced = typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      return prefersReduced ? 0 : 1;
+    }
+    const stored = parseInt(raw, 10);
     return (Number.isFinite(stored) ? stored : 100) / 100;
   };
 
@@ -6911,8 +6933,12 @@ PowerUps.reset();
     performSpecialAttack(now) {
       if (!player) return;
       this.lastSpecialAttack = now;
+      // The two generic (non-named) boss shapes get their own attack identity
+      // instead of sharing one interchangeable radial/charge/summon rotation.
+      if (this.kind === 'heavy') { this.performHeavyBossAttack(); return; }
+      if (this.kind === 'chaser') { this.performChaserBossAttack(); return; }
       this.attackPhase = (this.attackPhase + 1) % 3;
-      
+
       switch (this.attackPhase) {
         case 0: // Radial burst - fires in all directions
           for (let i = 0; i < 12; i++) {
@@ -6951,7 +6977,73 @@ PowerUps.reset();
           break;
       }
     }
-    
+
+    // Heavy-shape boss: slow, armor-plated juggernaut. Alternates a wide artillery
+    // spread with a ground-slam shockwave that punishes players who stay close.
+    performHeavyBossAttack() {
+      if (!player) return;
+      this.attackPhase = (this.attackPhase + 1) % 2;
+
+      if (this.attackPhase === 0) {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const baseAngle = Math.atan2(dy, dx);
+        const damage = this.baseDamage * 0.9;
+        const spread = 5;
+        for (let i = 0; i < spread; i++) {
+          const ang = baseAngle - 0.3 + (i / (spread - 1)) * 0.6;
+          const vel = { x: Math.cos(ang), y: Math.sin(ang) };
+          bullets.push(new Bullet(this.x, this.y, vel, damage, '#f97316', BASE.BULLET_SPEED * 0.55, BASE.BULLET_SIZE * 1.6, 0, true));
+        }
+        addParticles('muzzle', this.x, this.y, baseAngle, 10);
+        shakeScreen(6, 200);
+        addLogEntry('⚠️ Heavy artillery barrage!', '#f97316');
+      } else {
+        const slamRadius = this.size * 3.2;
+        const dist = Math.hypot(player.x - this.x, player.y - this.y);
+        if (dist < slamRadius) {
+          player.takeDamage(this.baseDamage * 1.8, this);
+        }
+        addParticles('ring', this.x, this.y, 0, 24, '#ea580c');
+        shakeScreen(11, 350);
+        addLogEntry('⚠️ Boss ground-slam shockwave!', '#ea580c');
+      }
+    }
+
+    // Chaser-shape boss: fast, relentless void reaper. Blinks toward the player
+    // then unleashes a converging burst — punishes standing still, not proximity.
+    performChaserBossAttack() {
+      if (!player) return;
+      this.attackPhase = (this.attackPhase + 1) % 2;
+
+      if (this.attackPhase === 0) {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const dist = Math.hypot(dx, dy) || 1;
+        const blinkDist = Math.min(dist - this.size * 1.5, 260);
+        if (blinkDist > 0) {
+          this.x += (dx / dist) * blinkDist;
+          this.y += (dy / dist) * blinkDist;
+        }
+        addParticles('sparks', this.x, this.y, 0, 18, '#e879f9');
+        shakeScreen(7, 180);
+        addLogEntry('⚠️ Boss blinks in close!', '#e879f9');
+      } else {
+        const dx = player.x - this.x;
+        const dy = player.y - this.y;
+        const baseAngle = Math.atan2(dy, dx);
+        const damage = this.baseDamage * 0.6;
+        const converge = 8;
+        for (let i = 0; i < converge; i++) {
+          const ang = (i / converge) * Math.PI * 2;
+          const vel = { x: Math.cos(ang), y: Math.sin(ang) };
+          bullets.push(new Bullet(this.x, this.y, vel, damage, '#a78bfa', BASE.BULLET_SPEED * 0.85, BASE.BULLET_SIZE * 1.1, 0, true));
+        }
+        addParticles('nova', this.x, this.y, 0, 16);
+        addLogEntry('⚠️ Boss unleashes a converging burst!', '#a78bfa');
+      }
+    }
+
     leviathanFirePhase(phase) {
       if (!player) return;
       const dx = player.x - this.x;
@@ -13424,7 +13516,7 @@ PowerUps.reset();
 
     // Save daily challenge best and restore Math.random
     if (window.DAILY_CHALLENGE_ACTIVE) {
-      import('./daily-challenge.js').then(({ saveDailyBest, getTodayBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted }) => {
+      import('./daily-challenge.js').then(({ saveDailyBest, getTodayBest, deactivateDailyChallenge, getDailyStreak, getTotalDailyChallengesCompleted, claimStreakReward }) => {
         // saveDailyBest() only overwrites the stored best when finalScore is
         // actually higher — but its return value was previously discarded,
         // so the display below unconditionally showed *this run's* score
@@ -13434,15 +13526,27 @@ PowerUps.reset();
         const bestEl = document.getElementById('dailyBestDisplay');
         if (bestEl) bestEl.textContent = `Best: ${getTodayBest().toLocaleString()}`;
 
+        const streak = getDailyStreak();
+
         // Update achievement stats for daily challenge completion
         try {
           const completedCount = getTotalDailyChallengesCompleted();
-          const streak = getDailyStreak();
           if (typeof window.updateAchievementStats === 'function') {
             window.updateAchievementStats({ dailyChallengesCompleted: completedCount, dailyStreak: streak });
           }
         } catch (e) {
           console.warn('[DailyChallenge] Achievement stats error:', e);
+        }
+
+        // Streak reward payoff — the streak was tracked but had zero payoff before
+        try {
+          const streakBonus = claimStreakReward();
+          if (streakBonus > 0) {
+            Save.addCredits(streakBonus);
+            showStreakBonusToast(streak, streakBonus);
+          }
+        } catch (e) {
+          console.warn('[DailyChallenge] Streak reward error:', e);
         }
       }).catch(err => console.warn('[DailyChallenge] Save failed:', err));
     }
@@ -13480,10 +13584,21 @@ PowerUps.reset();
   };
 
   // ── Accessibility ────────────────────────────────────────────────────────
+  const COLORBLIND_FILTER_IDS = {
+    deuteranopia: 'cbFilterDeuteranopia',
+    protanopia: 'cbFilterProtanopia',
+    tritanopia: 'cbFilterTritanopia',
+  };
+
   function applyHighContrast() {
     const enabled = localStorage.getItem('voidrift_high_contrast') === '1';
+    const cbMode = localStorage.getItem('voidrift_colorblind_mode') || 'off';
     if (dom.canvas) {
-      dom.canvas.style.filter = enabled ? 'contrast(1.35) saturate(1.5) brightness(1.05)' : '';
+      const filters = [];
+      const cbId = COLORBLIND_FILTER_IDS[cbMode];
+      if (cbId) filters.push(`url(#${cbId})`);
+      if (enabled) filters.push('contrast(1.35) saturate(1.5) brightness(1.05)');
+      dom.canvas.style.filter = filters.join(' ');
     }
   }
   window.applyHighContrast = applyHighContrast;
@@ -13544,6 +13659,36 @@ PowerUps.reset();
       setTimeout(() => { el.style.display = 'none'; }, 320);
       _missionToastTimeout = null;
     }, 2500);
+  }
+
+  let _streakToastTimeout = null;
+  function showStreakBonusToast(streak, credits) {
+    const el = document.getElementById('mission-complete-toast');
+    if (!el) {
+      try {
+        if (typeof addLogEntry === 'function') {
+          addLogEntry(`🔥 ${streak}-Day Streak: +${credits} credits!`, '#fbbf24');
+        }
+      } catch (_) {}
+      return;
+    }
+    // Share the mission-complete toast element/timers so a reward that fires
+    // right at game-over doesn't fight a still-visible mission toast.
+    if (_missionToastTimeout !== null) { clearTimeout(_missionToastTimeout); _missionToastTimeout = null; }
+    if (_streakToastTimeout !== null) { clearTimeout(_streakToastTimeout); _streakToastTimeout = null; }
+
+    el.innerHTML =
+      `<div class="mission-complete-toast__header">🔥 ${streak}-Day Streak</div>` +
+      `<div class="mission-complete-toast__name">+${credits} bonus credits</div>`;
+    el.style.display = 'block';
+    void el.offsetWidth;
+    el.classList.add('mission-complete-toast--visible');
+
+    _streakToastTimeout = setTimeout(() => {
+      el.classList.remove('mission-complete-toast--visible');
+      setTimeout(() => { el.style.display = 'none'; }, 320);
+      _streakToastTimeout = null;
+    }, 3000);
   }
 
   function updateMissionHUD() {

--- a/style.css
+++ b/style.css
@@ -5099,3 +5099,16 @@ label,
   color: #ffffff;
   letter-spacing: 0.05em;
 }
+
+/* ── Reduced motion ────────────────────────────────────────────────────────
+   Respect the OS-level accessibility setting: collapse looping/pulsing
+   animations (HUD glows, wave-card pulses, title/button pulses, toasts)
+   and instant-finish transitions, without removing the underlying layout. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

Five self-contained improvements from `WEEKLY_ROADMAP.md`'s **Day 6 — Accessibility and new content hooks** (added in #140). This is the next fully-unaddressed day in the roadmap: Day 1 was already covered end-to-end by #141, and Days 2–5 were partially cherry-picked by #144. Cross-checked against all currently-open daily-loop PRs (#139, #141, #142, #143, #144) to avoid overlapping any of their changes — none of them touch these five items.

- **[V] Colorblind-assist mode** — the existing "High Contrast Mode" toggle only boosts contrast/saturation and does nothing for actual red-green hue confusion. Added a real Deuteranopia/Protanopia/Tritanopia assist option (SVG `feColorMatrix` filters applied to the game canvas), selectable in Hangar → Settings, that shifts red/green apart toward blue/orange and composes with the existing High Contrast filter.
- **[V] `prefers-reduced-motion` support** — added a global CSS media query that collapses looping/pulsing animations (HUD glows, wave-card pulses, toasts) to near-zero duration, and screen shake now defaults to off under the OS reduced-motion setting when the player hasn't set an explicit shake-intensity preference.
- **[G] Unique boss attack patterns** — the two generic (non-named) boss "shapes" (`heavy` and `chaser`) previously shared one identical radial-burst/charge/summon rotation regardless of shape — a stat-boosted reskin with zero attack identity. `heavy` now alternates a wide artillery spread with a ground-slam AoE shockwave; `chaser` now blinks in close and follows up with a converging burst.
- **[G] Per-prestige permanent bonus** — `doPrestige()` previously only reset Pilot Level for a one-time cosmetic/title unlock with no ongoing payoff. Added a permanent +1.5%-per-tier credits/XP bonus (applied in `Save.addCredits`/`addXP`), surfaced in the Hangar prestige panel.
- **[M] Daily Challenge streak reward** — `getDailyStreak()` was tracked but had zero payoff. Every 3rd consecutive day now grants a one-time bonus-credit payout (idempotent per calendar day, so replaying today's challenge can't farm it), announced via a toast at game-over.

`ios/VoidRift/WebContent/` synced to match via the repo's own `sync-ios-content.sh`.

## Test plan

- [ ] `node --check` passes on all edited JS files (verified locally)
- [ ] In-browser: toggle each Colorblind Mode option in Hangar → Settings and confirm the canvas filter visibly shifts enemy/bullet hues
- [ ] Enable OS-level "reduce motion" and confirm HUD pulses/wave-card animations stop looping, and screen shake is off by default
- [ ] Trigger a non-named boss wave repeatedly and confirm `heavy` vs `chaser` bosses now fire visibly different special attacks
- [ ] Prestige once and confirm the Hangar panel shows the new credits/XP bonus, and that a run's earned credits/XP reflect it
- [ ] Complete Daily Challenge runs on 3 consecutive days and confirm a streak-bonus toast + credit payout appears on day 3, but not on a same-day replay

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XLqkhkqM965RcFFvaLZd8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLqkhkqM965RcFFvaLZd8X)_