### PR TITLE
Daily improvement loop: boss-kill tracking, mission toast, accuracy overflow, PB tie badge, HUD theme

### DIFF
--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -1708,14 +1708,20 @@
     },
     setRunBests(kills, timeSec, accuracyPct) {
       let changed = false;
-      if (kills > (this.data.bestKills || 0)) { this.data.bestKills = kills; changed = true; }
-      if (timeSec > (this.data.bestTimeSec || 0)) { this.data.bestTimeSec = timeSec; changed = true; }
-      if (accuracyPct > (this.data.bestAccuracyPct || 0)) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
+      // Capture strict-improvement flags before overwriting so a tied score
+      // doesn't get reported as a new PB (kills >= bestKills is true on a tie
+      // once bestKills has already been updated to match).
+      const isNewKills = kills > 0 && kills > (this.data.bestKills || 0);
+      const isNewTime = timeSec > 0 && timeSec > (this.data.bestTimeSec || 0);
+      const isNewAccuracy = accuracyPct > 0 && accuracyPct > (this.data.bestAccuracyPct || 0);
+      if (isNewKills) { this.data.bestKills = kills; changed = true; }
+      if (isNewTime) { this.data.bestTimeSec = timeSec; changed = true; }
+      if (isNewAccuracy) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
       if (changed) this.save();
       return {
-        newBestKills: kills > 0 && kills >= (this.data.bestKills || 0),
-        newBestTime: timeSec > 0 && timeSec >= (this.data.bestTimeSec || 0),
-        newBestAccuracy: accuracyPct > 0 && accuracyPct >= (this.data.bestAccuracyPct || 0)
+        newBestKills: isNewKills,
+        newBestTime: isNewTime,
+        newBestAccuracy: isNewAccuracy
       };
     },
     getUpgradeLevel(id) {
@@ -9535,6 +9541,8 @@ PowerUps.reset();
       addParticles('levelup', enemy.x, enemy.y, 0, 40);
       shakeScreen(20, 800);
       addLogEntry('☠️ LEVIATHAN DESTROYED!', '#FF2020');
+      // Leviathan is a boss for stats/achievements even though it doesn't use the generic isBoss flag
+      bossKilledThisRun++;
       // Nullify bossEntity so checkWaveCompletion fires
       if (bossEntity === enemy) bossEntity = null;
     } else if (wasBoss) {
@@ -10624,8 +10632,13 @@ PowerUps.reset();
             }
           }
           enemy.health -= hitDamage;
-          runShotsHit++;
-          waveShotsHit++;
+          // Count each bullet as at most one "hit" for accuracy stats, even when
+          // piercing lets it strike multiple enemies — otherwise accuracy can exceed 100%.
+          if (!bullet.countedHit) {
+            bullet.countedHit = true;
+            runShotsHit++;
+            waveShotsHit++;
+          }
 
           // Phase 1: Show damage number
           spawnDamageNumber(enemy.x, enemy.y, hitDamage, isCrit);
@@ -13511,14 +13524,23 @@ PowerUps.reset();
     if (hud) hud.style.display = 'none';
   }
 
+  function hudAccentToRgba(hex, alpha) {
+    const h = hex.replace('#', '');
+    const r = parseInt(h.substring(0, 2), 16);
+    const g = parseInt(h.substring(2, 4), 16);
+    const b = parseInt(h.substring(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
   let _missionToastTimeout = null;
   function showMissionCompleteToast(name) {
     const el = document.getElementById('mission-complete-toast');
+    const accent = getHudAccent();
     if (!el) {
       // Fallback to action log if DOM element not found
       try {
         if (typeof addLogEntry === 'function') {
-          addLogEntry(`MISSION COMPLETE: ${name}`, '#4ade80');
+          addLogEntry(`MISSION COMPLETE: ${name}`, accent);
         }
       } catch (_) {}
       return;
@@ -13530,8 +13552,11 @@ PowerUps.reset();
       _missionToastTimeout = null;
     }
 
+    // Apply the player's chosen HUD theme (Settings > HUD Theme) to the toast accent
+    el.style.borderColor = accent;
+    el.style.boxShadow = `0 0 24px ${hudAccentToRgba(accent, 0.25)}`;
     el.innerHTML =
-      `<div class="mission-complete-toast__header">&#10003; Mission Complete</div>` +
+      `<div class="mission-complete-toast__header" style="color:${accent}">&#10003; Mission Complete</div>` +
       `<div class="mission-complete-toast__name">${name}</div>`;
     el.style.display = 'block';
     // Force reflow so the transition plays from the start state
@@ -14111,6 +14136,11 @@ PowerUps.reset();
       } catch(e) {
         window.missionSystem.checkDailyRefresh();
       }
+      // Seed the "already seen" set with missions completed before this page load
+      // so the completion toast/counter only fires for missions finished just now.
+      (window.missionSystem.dailyMissions || []).forEach((m) => {
+        if (m.completed || m.claimed) _missionPrevCompleted.add(m.id || m.name);
+      });
       updateMissionHUD();
     }
     // Initialize TechFragmentSystem

--- a/script.js
+++ b/script.js
@@ -1708,14 +1708,20 @@
     },
     setRunBests(kills, timeSec, accuracyPct) {
       let changed = false;
-      if (kills > (this.data.bestKills || 0)) { this.data.bestKills = kills; changed = true; }
-      if (timeSec > (this.data.bestTimeSec || 0)) { this.data.bestTimeSec = timeSec; changed = true; }
-      if (accuracyPct > (this.data.bestAccuracyPct || 0)) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
+      // Capture strict-improvement flags before overwriting so a tied score
+      // doesn't get reported as a new PB (kills >= bestKills is true on a tie
+      // once bestKills has already been updated to match).
+      const isNewKills = kills > 0 && kills > (this.data.bestKills || 0);
+      const isNewTime = timeSec > 0 && timeSec > (this.data.bestTimeSec || 0);
+      const isNewAccuracy = accuracyPct > 0 && accuracyPct > (this.data.bestAccuracyPct || 0);
+      if (isNewKills) { this.data.bestKills = kills; changed = true; }
+      if (isNewTime) { this.data.bestTimeSec = timeSec; changed = true; }
+      if (isNewAccuracy) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
       if (changed) this.save();
       return {
-        newBestKills: kills > 0 && kills >= (this.data.bestKills || 0),
-        newBestTime: timeSec > 0 && timeSec >= (this.data.bestTimeSec || 0),
-        newBestAccuracy: accuracyPct > 0 && accuracyPct >= (this.data.bestAccuracyPct || 0)
+        newBestKills: isNewKills,
+        newBestTime: isNewTime,
+        newBestAccuracy: isNewAccuracy
       };
     },
     getUpgradeLevel(id) {
@@ -9535,6 +9541,8 @@ PowerUps.reset();
       addParticles('levelup', enemy.x, enemy.y, 0, 40);
       shakeScreen(20, 800);
       addLogEntry('☠️ LEVIATHAN DESTROYED!', '#FF2020');
+      // Leviathan is a boss for stats/achievements even though it doesn't use the generic isBoss flag
+      bossKilledThisRun++;
       // Nullify bossEntity so checkWaveCompletion fires
       if (bossEntity === enemy) bossEntity = null;
     } else if (wasBoss) {
@@ -10624,8 +10632,13 @@ PowerUps.reset();
             }
           }
           enemy.health -= hitDamage;
-          runShotsHit++;
-          waveShotsHit++;
+          // Count each bullet as at most one "hit" for accuracy stats, even when
+          // piercing lets it strike multiple enemies — otherwise accuracy can exceed 100%.
+          if (!bullet.countedHit) {
+            bullet.countedHit = true;
+            runShotsHit++;
+            waveShotsHit++;
+          }
 
           // Phase 1: Show damage number
           spawnDamageNumber(enemy.x, enemy.y, hitDamage, isCrit);
@@ -13511,14 +13524,23 @@ PowerUps.reset();
     if (hud) hud.style.display = 'none';
   }
 
+  function hudAccentToRgba(hex, alpha) {
+    const h = hex.replace('#', '');
+    const r = parseInt(h.substring(0, 2), 16);
+    const g = parseInt(h.substring(2, 4), 16);
+    const b = parseInt(h.substring(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
   let _missionToastTimeout = null;
   function showMissionCompleteToast(name) {
     const el = document.getElementById('mission-complete-toast');
+    const accent = getHudAccent();
     if (!el) {
       // Fallback to action log if DOM element not found
       try {
         if (typeof addLogEntry === 'function') {
-          addLogEntry(`MISSION COMPLETE: ${name}`, '#4ade80');
+          addLogEntry(`MISSION COMPLETE: ${name}`, accent);
         }
       } catch (_) {}
       return;
@@ -13530,8 +13552,11 @@ PowerUps.reset();
       _missionToastTimeout = null;
     }
 
+    // Apply the player's chosen HUD theme (Settings > HUD Theme) to the toast accent
+    el.style.borderColor = accent;
+    el.style.boxShadow = `0 0 24px ${hudAccentToRgba(accent, 0.25)}`;
     el.innerHTML =
-      `<div class="mission-complete-toast__header">&#10003; Mission Complete</div>` +
+      `<div class="mission-complete-toast__header" style="color:${accent}">&#10003; Mission Complete</div>` +
       `<div class="mission-complete-toast__name">${name}</div>`;
     el.style.display = 'block';
     // Force reflow so the transition plays from the start state
@@ -14111,6 +14136,11 @@ PowerUps.reset();
       } catch(e) {
         window.missionSystem.checkDailyRefresh();
       }
+      // Seed the "already seen" set with missions completed before this page load
+      // so the completion toast/counter only fires for missions finished just now.
+      (window.missionSystem.dailyMissions || []).forEach((m) => {
+        if (m.completed || m.claimed) _missionPrevCompleted.add(m.id || m.name);
+      });
       updateMissionHUD();
     }
     // Initialize TechFragmentSystem


### PR DESCRIPTION
## Summary

Five small, self-contained fixes continuing the daily Void Rift improvement loop.

- **Leviathan boss-kill tracking**: Leviathan is spawned with `isBoss` hard-coded `false` and handled in its own death branch (`wasLeviathan`), so killing a Leviathan never incremented `bossKilledThisRun`. That counter feeds the Boss Hunter/Boss Slayer achievements and the boss-kill stat sent to Game Center/social — so Leviathan kills silently didn't count toward any of it. Now increments the counter in the Leviathan death branch too.
- **Retroactive mission-complete toast**: `_missionPrevCompleted` always started as an empty `Set`, but `updateMissionHUD()` runs immediately after mission state loads from localStorage at boot. Any mission already completed earlier that day would fire the "Mission Complete" toast and increment `missionsCompletedThisRun` again on page load. Now the set is seeded with already-completed/claimed mission IDs right after load, before the first `updateMissionHUD()` call.
- **Accuracy could exceed 100%**: piercing bullets (Rail Lance, Void Cannon) `continue` through multiple enemies instead of `break`-ing after one hit, and each pass incremented `runShotsHit`/`waveShotsHit` — so one fired shot could register several "hits". Now each bullet counts as at most one hit for accuracy purposes via a `bullet.countedHit` flag.
- **PB badge shown on a tie, not just a new record**: `Save.setRunBests()` updated the stored best values with `>` but computed the returned `newBest*` flags with `>=` against those same (already-updated) values — so tying a personal best (not beating it) still showed the gold PB badge and per-stat PB label. Now the strict-improvement flags are captured before the stored values are overwritten.
- **HUD Theme picker was a no-op**: Settings has a 5-color HUD theme picker that persists to `localStorage['voidrift_hud_theme']`, and `getHudAccent()` reads it back — but nothing ever called `getHudAccent()`. Now it's wired into the mission-complete toast's border/glow/header color.

`ios/VoidRift/WebContent/script.js` synced to match (only file that had drifted from `sync-ios-content.sh`'s output).

## Test plan

- [x] `node --check script.js` passes
- [ ] Manual playtest: pierce a few enemies with Rail Lance/Void Cannon and confirm accuracy stays ≤100%
- [ ] Manual playtest: kill a Leviathan and confirm Boss Hunter progress/boss-kill stat increments
- [ ] Manual playtest: reload with an already-completed daily mission and confirm no toast fires on load
- [ ] Manual playtest: tie a previous best (kills/time/accuracy) and confirm no PB badge shows
- [ ] Manual playtest: change HUD Theme in Settings and confirm the mission-complete toast reflects it

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017uNfkSJRngMxj8jan78uDY

---
_Generated by [Claude Code](https://claude.ai/code/session_017uNfkSJRngMxj8jan78uDY)_