### PR TITLE
Daily improvement loop: 5 gameplay/social bug fixes

### DIFF
--- a/hangar-ui.js
+++ b/hangar-ui.js
@@ -3534,6 +3534,16 @@ function handlePrestige() {
   // Increment prestige (also saves hangar)
   prestigePilot(_hangarState);
 
+  // Also advance the Auth-based prestige counter so the prestige_1/5/10
+  // achievements and Game Center reporting (which key off
+  // Auth.playerProfile.prestige, not this hangar's own counter) actually
+  // unlock — this button previously left that counter untouched entirely.
+  if (typeof window !== 'undefined' && window.Auth && window.Auth.playerProfile) {
+    window.Auth.playerProfile.prestige = (window.Auth.playerProfile.prestige || 0) + 1;
+    window.Auth.saveProfile();
+    window.Auth.checkAchievements();
+  }
+
   // Re-open with same options so the updated badge is visible
   const savedOptions = Object.assign({}, _options);
   closeHangar();

--- a/ios/VoidRift/WebContent/script.js
+++ b/ios/VoidRift/WebContent/script.js
@@ -1708,16 +1708,18 @@
       this.save();
     },
     setRunBests(kills, timeSec, accuracyPct) {
-      let changed = false;
-      if (kills > (this.data.bestKills || 0)) { this.data.bestKills = kills; changed = true; }
-      if (timeSec > (this.data.bestTimeSec || 0)) { this.data.bestTimeSec = timeSec; changed = true; }
-      if (accuracyPct > (this.data.bestAccuracyPct || 0)) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
-      if (changed) this.save();
-      return {
-        newBestKills: kills > 0 && kills >= (this.data.bestKills || 0),
-        newBestTime: timeSec > 0 && timeSec >= (this.data.bestTimeSec || 0),
-        newBestAccuracy: accuracyPct > 0 && accuracyPct >= (this.data.bestAccuracyPct || 0)
-      };
+      // Compute the "new best" flags before mutating the stored bests — doing
+      // it after (as before) compared each stat against its own just-updated
+      // value, so merely tying a previous best (not beating it) still read
+      // as a new best.
+      const newBestKills = kills > 0 && kills > (this.data.bestKills || 0);
+      const newBestTime = timeSec > 0 && timeSec > (this.data.bestTimeSec || 0);
+      const newBestAccuracy = accuracyPct > 0 && accuracyPct > (this.data.bestAccuracyPct || 0);
+      if (newBestKills) this.data.bestKills = kills;
+      if (newBestTime) this.data.bestTimeSec = timeSec;
+      if (newBestAccuracy) this.data.bestAccuracyPct = accuracyPct;
+      if (newBestKills || newBestTime || newBestAccuracy) this.save();
+      return { newBestKills, newBestTime, newBestAccuracy };
     },
     getUpgradeLevel(id) {
       return this.data.upgrades[id] || 0;
@@ -9419,11 +9421,10 @@ PowerUps.reset();
       dropSupply(enemy.x + rand(-40, 40), enemy.y + rand(-40, 40));
       Save.addCredits(250);
       if (window.missionSystem) window.missionSystem.trackCredits(250);
+      // LEVIATHAN SLAYER achievement is unlocked via Auth.updateGameStats() at
+      // game over (which adds leviathanKilledThisRun) — incrementing
+      // Auth.playerProfile.leviathanKills here too double-counted every kill.
       leviathanKilledThisRun++;
-      // Unlock LEVIATHAN SLAYER achievement
-      Auth.playerProfile.leviathanKills = (Auth.playerProfile.leviathanKills || 0) + 1;
-      Auth.saveProfile();
-      Auth.checkAchievements();
     } else if (wasElite) {
       dropCoin(enemy.x + rand(-20, 20), enemy.y + rand(-20, 20));
       dropCoin(enemy.x + rand(-20, 20), enemy.y + rand(-20, 20));
@@ -10701,7 +10702,11 @@ PowerUps.reset();
         const rawCoinCredits = killComboMultiplier > 1 ? killComboMultiplier : 1;
         // Fortune Module shop upgrade ('luck'): was purchasable but its level
         // was never read anywhere — 5% more credits per level, up to 30% at max level 6.
-        const coinCredits = Math.round(rawCoinCredits * (1 + Save.getUpgradeLevel('luck') * 0.05));
+        // perkMultipliers.coinBonus (Scavenger perk, Salvage Network hangar upgrade,
+        // Prestige bonus) advertise "+X% credits from kills" but were only ever
+        // consumed as a bonus-coin-drop chance below — never applied to the actual
+        // credit value awarded here.
+        const coinCredits = Math.round(rawCoinCredits * (1 + Save.getUpgradeLevel('luck') * 0.05) * perkMultipliers.coinBonus);
         Save.addCredits(coinCredits);
         if (window.missionSystem) window.missionSystem.trackCredits(coinCredits);
         addXP(6);

--- a/ios/VoidRift/WebContent/social-hub.js
+++ b/ios/VoidRift/WebContent/social-hub.js
@@ -383,6 +383,11 @@ const SocialHub = {
   confirmPrestige() {
     this.closeModal('prestigeConfirmModal');
     this.closeModal('profileModal');
+    // Actually perform the prestige — this previously only showed a success
+    // toast without ever resetting the pilot level or granting any reward.
+    if (typeof window.Auth !== 'undefined' && typeof window.Auth.doPrestige === 'function') {
+      window.Auth.doPrestige();
+    }
     // Show success notification
     const toast = document.createElement('div');
     toast.className = 'achievement-toast';

--- a/script.js
+++ b/script.js
@@ -1708,16 +1708,18 @@
       this.save();
     },
     setRunBests(kills, timeSec, accuracyPct) {
-      let changed = false;
-      if (kills > (this.data.bestKills || 0)) { this.data.bestKills = kills; changed = true; }
-      if (timeSec > (this.data.bestTimeSec || 0)) { this.data.bestTimeSec = timeSec; changed = true; }
-      if (accuracyPct > (this.data.bestAccuracyPct || 0)) { this.data.bestAccuracyPct = accuracyPct; changed = true; }
-      if (changed) this.save();
-      return {
-        newBestKills: kills > 0 && kills >= (this.data.bestKills || 0),
-        newBestTime: timeSec > 0 && timeSec >= (this.data.bestTimeSec || 0),
-        newBestAccuracy: accuracyPct > 0 && accuracyPct >= (this.data.bestAccuracyPct || 0)
-      };
+      // Compute the "new best" flags before mutating the stored bests — doing
+      // it after (as before) compared each stat against its own just-updated
+      // value, so merely tying a previous best (not beating it) still read
+      // as a new best.
+      const newBestKills = kills > 0 && kills > (this.data.bestKills || 0);
+      const newBestTime = timeSec > 0 && timeSec > (this.data.bestTimeSec || 0);
+      const newBestAccuracy = accuracyPct > 0 && accuracyPct > (this.data.bestAccuracyPct || 0);
+      if (newBestKills) this.data.bestKills = kills;
+      if (newBestTime) this.data.bestTimeSec = timeSec;
+      if (newBestAccuracy) this.data.bestAccuracyPct = accuracyPct;
+      if (newBestKills || newBestTime || newBestAccuracy) this.save();
+      return { newBestKills, newBestTime, newBestAccuracy };
     },
     getUpgradeLevel(id) {
       return this.data.upgrades[id] || 0;
@@ -9419,11 +9421,10 @@ PowerUps.reset();
       dropSupply(enemy.x + rand(-40, 40), enemy.y + rand(-40, 40));
       Save.addCredits(250);
       if (window.missionSystem) window.missionSystem.trackCredits(250);
+      // LEVIATHAN SLAYER achievement is unlocked via Auth.updateGameStats() at
+      // game over (which adds leviathanKilledThisRun) — incrementing
+      // Auth.playerProfile.leviathanKills here too double-counted every kill.
       leviathanKilledThisRun++;
-      // Unlock LEVIATHAN SLAYER achievement
-      Auth.playerProfile.leviathanKills = (Auth.playerProfile.leviathanKills || 0) + 1;
-      Auth.saveProfile();
-      Auth.checkAchievements();
     } else if (wasElite) {
       dropCoin(enemy.x + rand(-20, 20), enemy.y + rand(-20, 20));
       dropCoin(enemy.x + rand(-20, 20), enemy.y + rand(-20, 20));
@@ -10701,7 +10702,11 @@ PowerUps.reset();
         const rawCoinCredits = killComboMultiplier > 1 ? killComboMultiplier : 1;
         // Fortune Module shop upgrade ('luck'): was purchasable but its level
         // was never read anywhere — 5% more credits per level, up to 30% at max level 6.
-        const coinCredits = Math.round(rawCoinCredits * (1 + Save.getUpgradeLevel('luck') * 0.05));
+        // perkMultipliers.coinBonus (Scavenger perk, Salvage Network hangar upgrade,
+        // Prestige bonus) advertise "+X% credits from kills" but were only ever
+        // consumed as a bonus-coin-drop chance below — never applied to the actual
+        // credit value awarded here.
+        const coinCredits = Math.round(rawCoinCredits * (1 + Save.getUpgradeLevel('luck') * 0.05) * perkMultipliers.coinBonus);
         Save.addCredits(coinCredits);
         if (window.missionSystem) window.missionSystem.trackCredits(coinCredits);
         addXP(6);

--- a/social-hub.js
+++ b/social-hub.js
@@ -383,6 +383,11 @@ const SocialHub = {
   confirmPrestige() {
     this.closeModal('prestigeConfirmModal');
     this.closeModal('profileModal');
+    // Actually perform the prestige — this previously only showed a success
+    // toast without ever resetting the pilot level or granting any reward.
+    if (typeof window.Auth !== 'undefined' && typeof window.Auth.doPrestige === 'function') {
+      window.Auth.doPrestige();
+    }
     // Show success notification
     const toast = document.createElement('div');
     toast.className = 'achievement-toast';


### PR DESCRIPTION
## Summary

Five small, surgical fixes found in this iteration of the daily improvement loop, following the same pattern as prior "Daily improvement loop" commits on this repo.

1. **Leviathan kill stat double-counted** (`script.js`) — `handleEnemyDeath` incremented `Auth.playerProfile.leviathanKills` at kill-time *and* fed it into `Auth.updateGameStats()` at game-over, doubling the stat every run. Removed the redundant kill-time increment so it follows the same single-source-of-truth pattern as `bossKills`/`eliteKills`/`voidSurgeKills`.

2. **Header Prestige button disconnected from prestige achievements** (`hangar-ui.js`) — the Hangar header "PRESTIGE" button only incremented the hangar's own `_hangarState.prestige` counter (credit bonus + badge), never `Auth.playerProfile.prestige`, which is what actually gates the `prestige_1/5/10` achievements and Game Center reporting. Now also updates and saves the Auth-side counter and re-checks achievements.

3. **Per-run PB badges false-positive on ties** (`script.js`) — `Save.setRunBests()` computed the "new best" flags with `>=` *after* overwriting the stored bests, so tying (not beating) a previous best still lit the "NEW BEST" badge. Flags are now computed with `>` before the stored values are mutated.

4. **SocialHub "Prestige Now" button is a no-op** (`social-hub.js`) — `confirmPrestige()` closed the modals and showed a "PRESTIGE COMPLETE!" toast but never actually reset the pilot level or granted prestige rewards. Now calls `Auth.doPrestige()` before showing the success toast.

5. **Credit-bonus perks not applied to coin pickups** (`script.js`) — `perkMultipliers.coinBonus` (Scavenger perk "+30% Credits from Kills", Salvage Network hangar upgrade, Prestige credit bonus) was only ever consumed as a probability check for an *extra* coin drop; the actual credit value awarded per coin pickup never factored it in. Added the multiplier to the coin-credit calculation.

Fixes 1, 3, and 5 (root-level `script.js`) are mirrored in the synced `ios/VoidRift/WebContent/` copy for consistency with the iOS app shell, matching prior daily-loop commits.

## Test plan

- [x] `node --check` on all modified files (syntax valid)
- [ ] `npm test` — blocked in this environment: `jest-environment-jsdom` isn't installed (pre-existing repo issue, unrelated to this change)
- [ ] Manual playtest of prestige flow (Hangar header button + SocialHub profile modal) and a run with the Scavenger/Salvage Network perks active


---
_Generated by [Claude Code](https://claude.ai/code/session_018vSY8evVjWRz9sXWK5Tv2P)_